### PR TITLE
MPT-15566: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    versioning-strategy: "auto"
+    groups:
+      python-production:
+        dependency-type: "production"
+      python-development:
+        dependency-type: "development"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "08:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "08:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    open-pull-requests-limit: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-15566](https://softwareone.atlassian.net/browse/MPT-15566)

- Add Dependabot configuration file to automate dependency updates
- Configure UV (Python/uv) package updates to run weekly on Mondays at 08:00 UTC with separate groups for production and development dependencies
- Configure Docker image updates to run monthly at 08:00 UTC
- Configure GitHub Actions updates to run monthly at 08:00 UTC
- Set all ecosystems to use "deps" prefix in commit messages with appropriate scoping
- Limit open PRs per ecosystem to a maximum of 5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-15566]: https://softwareone.atlassian.net/browse/MPT-15566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ