### PR TITLE
MPT-16808: add specific path_instructions to follow ruff and flake rules f…

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,12 +37,13 @@ reviews:
   path_filters:
       - "!.gitignore"
   path_instructions:
-      - path: "**/*.py"
-        instructions: |
-          Do not suggest formatting changes or mention code formatting using Black. Instead use Ruff or Flake8
       - path: "**/*"
         instructions: |
-          When reviewing subsequent commits, always check if previous review comments have been addressed and acknowledge resolved issues.
+          For each subsequent commit in this PR, explicitly verify if previous review comments have been resolved
+      - path: "**/*.py"
+        instructions: |
+          Follow the linting rules defined in pyproject.toml under [tool.ruff] and [tool.flake8] sections.
+          For formatting, use Ruff instead of Black. Do not suggest Black formatting changes.
   abort_on_close: true
   disable_cache: false
   auto_review:


### PR DESCRIPTION
…rom pyproject.toml file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-16808](https://softwareone.atlassian.net/browse/MPT-16808)

- Update `.coderabbit.yaml` path_instructions:
  - `**/*`: require explicit verification in each subsequent commit that previous review comments have been resolved
  - `**/*.py`: enforce linting rules from `pyproject.toml` ([tool.ruff], [tool.flake8]) and require using Ruff for formatting (do not suggest Black)
- Remove previous combined/all-files path instruction in favor of the two specific rules above
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16808]: https://softwareone.atlassian.net/browse/MPT-16808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ