### PR TITLE
MPT-16890: improve Dockerfile, Makefile, README and compose.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim as base
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 WORKDIR /extension
 
@@ -9,7 +9,7 @@ ENV PATH=/opt/venv/bin:$PATH
 
 FROM base AS build
 
-COPY . /extension
+COPY . .
 
 RUN uv sync --frozen --no-cache --all-groups --active
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "  make bash             - Open a bash shell in the app container."
 	@echo "  make build            - Build images."
 	@echo "  make check            - Check code quality with ruff."
-	@echo "  make check-all        - Run check, format and tests."
+	@echo "  make check-all        - Run checks and tests."
 	@echo "  make down             - Stop and remove containers."
 	@echo "  make format           - Format code."
 	@echo "  make review           - Check the code in the cli by running CodeRabbit."
@@ -25,9 +25,7 @@ build:
 check:
 	  $(DC) run --rm app bash -c "ruff format --check . && ruff check . && flake8 . && uv lock --check"
 
-check-all:
-	  make check
-	  make test
+check-all: check test
 
 down:
 	  $(DC) down
@@ -45,4 +43,4 @@ shell:
 	  $(DC) run --rm -it app bash -c "swoext shell"
 
 test:
-	  $(DC) run --rm app pytest $(args) .
+	  $(DC) run --rm app pytest $(if $(args),$(args),.)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Common development workflows are wrapped in the `makefile`:
 - `make bash` – start the app container and open a bash shell
 - `make build` – build the application image for development
 - `make check` – run code quality checks (ruff, flake8, lockfile check)
-- `make check-all` – run checks, formatting, and tests
+- `make check-all` – run checks and tests
 - `make format` – apply formatting and import fixes
 - `make down` – stop and remove containers
 - `make review` –  check the code in the cli by running CodeRabbit

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,8 @@
 services:
   app:
-    container_name: ext_playground
     build:
       context: .
       target: dev
-      dockerfile: Dockerfile
-    working_dir: /extension
     command: swoext run --no-color
     volumes:
       - .:/extension


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-16890](https://softwareone.atlassian.net/browse/MPT-16890)

- Dockerfile: normalize multi-stage alias casing to `AS base` and simplify COPY to use the current directory as destination
- Makefile: update `check-all` help text and refactor to use prerequisite syntax (`check-all: check test`); make `test` default to current directory when no args are provided
- README.md: update docs to reflect `check-all` no longer runs formatting
- compose.yaml: remove explicit `container_name`, `dockerfile`, and `working_dir` entries to simplify Compose config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16890]: https://softwareone.atlassian.net/browse/MPT-16890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ