### PR TITLE
MPT-16890: update mypy config to match standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,4 @@ repos:
       - id: mypy
         args: ["--config-file=pyproject.toml", "."]
         pass_filenames: false
+        additional_dependencies: [django-stubs == 4.2.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "hatchling.build"
 testpaths = "tests"
 pythonpath = "."
 addopts = "--cov=swo_playground --cov-report=term-missing --cov-report=xml --import-mode=importlib"
+DJANGO_SETTINGS_MODULE = "mpt_extension_sdk.runtime.djapp.conf.default"
 log_cli = false
 filterwarnings = []
 
@@ -190,8 +191,24 @@ convention = "google"
 known-third-party = ["swo"]
 
 [tool.mypy]
-warn_no_return = false
-
-[[tool.mypy.overrides]]
-module = "django.*"
+# The mypy configurations: http://bit.ly/2zEl9WI
+disable_error_code = ["import-untyped"]
+enable_error_code = [
+  "truthy-bool",
+  "truthy-iterable",
+  "redundant-expr",
+  "unused-awaitable",
+  "ignore-without-code",
+  "possibly-undefined",
+  "redundant-self",
+  "explicit-override",
+  "mutable-override",
+  "unimported-reveal",
+  "deprecated",
+]
+exclude = ["tests"]
+exclude_gitignore = true
 ignore_missing_imports = true
+local_partial_types = true
+strict = true
+warn_unreachable = true

--- a/swo_playground/api.py
+++ b/swo_playground/api.py
@@ -5,12 +5,12 @@ from typing import Annotated, Any, Literal
 
 from django.conf import settings
 from django.http import HttpRequest
-from mpt_extension_sdk.core.extension import Extension  # type: ignore[import-untyped]
-from mpt_extension_sdk.core.security import JWTAuth  # type: ignore[import-untyped]
-from mpt_extension_sdk.flows.context import Context  # type: ignore[import-untyped]
-from mpt_extension_sdk.mpt_http.base import MPTClient  # type: ignore[import-untyped]
-from mpt_extension_sdk.mpt_http.mpt import get_webhook  # type: ignore[import-untyped]
-from mpt_extension_sdk.runtime.djapp.conf import get_for_product  # type: ignore[import-untyped]
+from mpt_extension_sdk.core.extension import Extension
+from mpt_extension_sdk.core.security import JWTAuth
+from mpt_extension_sdk.flows.context import Context
+from mpt_extension_sdk.mpt_http.base import MPTClient
+from mpt_extension_sdk.mpt_http.mpt import get_webhook
+from mpt_extension_sdk.runtime.djapp.conf import get_for_product
 from ninja import Body, Schema
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ logger.setLevel(logging.INFO)
 ext = Extension()
 
 
-class Error(Schema):
+class Error(Schema):  # type: ignore[misc]
     """MPT API error message."""
 
     id: str
@@ -44,45 +44,19 @@ def jwt_secret_callback(client: MPTClient, claims: Mapping[str, Any]) -> str:
     return str(get_for_product(settings, "WEBHOOKS_SECRETS", product_id))
 
 
-@ext.api.get(
-    "/",
-    description="Root endpoint.",
-    response={
-        200: dict,
-        400: Error,
-    },
-)  # type: ignore[misc]
-def root(request: ExtensionHttpRequest) -> Response:
-    """Root endpoint."""
-    return 200, {"message": "Ok"}
-
-
-@ext.api.get(
-    "/healthcheck",
-    description="Healthcheck endpoint.",
-    response={
-        200: dict,
-        400: Error,
-    },
-)  # type: ignore[misc]
-def healthcheck(request: ExtensionHttpRequest) -> Response:
-    """Returns 200 healthy."""
-    return 200, {"status": "Healthy"}
-
-
-@ext.api.post(
+@ext.api.post(  # type: ignore[untyped-decorator]
     "/v1/orders/validate",
     response={
         200: dict,
         400: Error,
     },
     auth=JWTAuth(jwt_secret_callback),
-)  # type: ignore[misc]
+)
 def process_order_validation(
     request: ExtensionHttpRequest,
     order: Annotated[dict[str, Any] | None, Body()] = None,
 ) -> Response:
-    """Process order draft validatin."""
+    """Process order draft validation."""
     context = Context(order=order)
     try:
         validated_order = validate_order(request.client, context)

--- a/swo_playground/events.py
+++ b/swo_playground/events.py
@@ -1,12 +1,11 @@
-from mpt_extension_sdk.core.events.dataclasse import Event  # type: ignore[import-untyped]
-from mpt_extension_sdk.mpt_http.base import MPTClient  # type: ignore[import-untyped]
+from mpt_extension_sdk.core.events.dataclasses import Event
+from mpt_extension_sdk.mpt_http.base import MPTClient
 
-from swo_playground.api import logger
-from swo_playground.apps import ext
+from swo_playground.api import ext, logger
 from swo_playground.steps import purchase_pipeline
 
 
-@ext.events.listener("orders")  # type: ignore[misc]
+@ext.events.listener("orders")  # type: ignore[untyped-decorator]
 def process_order_fulfillment(client: MPTClient, event: Event) -> None:
     """Event handler for FF orders."""
     context = event.data

--- a/swo_playground/management/commands/hello.py
+++ b/swo_playground/management/commands/hello.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, override
 
 from django.core.management.base import BaseCommand
 
@@ -8,6 +8,7 @@ class Command(BaseCommand):
 
     help = "Hello world"
 
+    @override
     def handle(self, *args: Any, **options: Any) -> None:  # noqa: WPS110
         """Run command."""
         self.stdout.write("Hello world!!!", ending="\n")

--- a/swo_playground/steps.py
+++ b/swo_playground/steps.py
@@ -1,17 +1,17 @@
 import logging
 
-from mpt_extension_sdk.flows.context import Context  # type: ignore[import-untyped]
-from mpt_extension_sdk.flows.pipeline import (  # type: ignore[import-untyped]
+from mpt_extension_sdk.flows.context import Context
+from mpt_extension_sdk.flows.pipeline import (
     NextStep,
     Pipeline,
     Step,
 )
-from mpt_extension_sdk.mpt_http.base import MPTClient  # type: ignore[import-untyped]
-from mpt_extension_sdk.mpt_http.mpt import (  # type: ignore[import-untyped]
+from mpt_extension_sdk.mpt_http.base import MPTClient
+from mpt_extension_sdk.mpt_http.mpt import (
     complete_order,
     create_subscription,
 )
-from mpt_extension_sdk.mpt_http.wrap_http_error import MPTAPIError  # type: ignore[import-untyped]
+from mpt_extension_sdk.mpt_http.wrap_http_error import MPTAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class NoopStep(Step):  # type: ignore[misc]
     """
 
     def __call__(self, client: MPTClient, context: Context, next_step: NextStep) -> None:
-        """Exectute step."""
+        """Execute step."""
         logger.info("%s - No operation step executed.", context.order_id)
         next_step(client, context)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
+from mpt_extension_sdk.mpt_http.base import MPTClient
 
 
 @pytest.fixture(autouse=True)
 def settings_configuration(settings):
-    settings.INSTALLED_APPS += ["swo_playground.apps.ExtensionConfig"]
+    settings.INSTALLED_APPS = settings.INSTALLED_APPS + ["swo_playground.apps.ExtensionConfig"]  # noqa: PLR6104, RUF005
+
+
+@pytest.fixture
+def mock_mpt_client(mocker):
+    return mocker.Mock(spec=MPTClient)

--- a/tests/management/commands/test_hello.py
+++ b/tests/management/commands/test_hello.py
@@ -1,0 +1,8 @@
+from django.core.management import call_command
+
+
+def test_hello(capsys):
+    call_command("hello")  # act
+
+    out_log = capsys.readouterr().out
+    assert out_log == "Hello world!!!\n"

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,0 +1,11 @@
+from mpt_extension_sdk.core.extension import Extension
+
+from swo_playground.apps import ExtensionConfig
+
+
+def test_apps():
+    result = ExtensionConfig
+
+    assert result.name == "swo_playground"
+    assert result.verbose_name == "SWO Playground Extension"
+    assert isinstance(result.extension, Extension)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,17 @@
+from mpt_extension_sdk.core.events.dataclasses import Event
+
+from swo_playground.events import process_order_fulfillment
+
+
+def test_process_order_fulfillment(mocker, mock_mpt_client, caplog):
+    mock_purchase_pipeline_run = mocker.patch(
+        "swo_playground.steps.purchase_pipeline.run", autospec=True
+    )
+    mock_data = mocker.Mock(order_id="fake-order-id")
+    mock_event = mocker.Mock(data=mock_data, spec=Event)
+
+    process_order_fulfillment(mock_mpt_client, mock_event)  # act
+
+    mock_purchase_pipeline_run.assert_called_once_with(mock_mpt_client, mock_data)
+    assert "fake-order-id - Order fulfilling..." in caplog.text
+    assert "fake-order-id - Order fulfilled." in caplog.text


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-16890](https://softwareone.atlassian.net/browse/MPT-16890)

- Tightened mypy configuration in pyproject.toml: replaced old mypy block with new settings (disable/enable error codes, exclude tests, exclude_gitignore, ignore_missing_imports, local_partial_types, strict, warn_unreachable) and removed legacy overrides.
- Added django-stubs (django-stubs == 4.2.*) to the mypy hook additional_dependencies in .pre-commit-config.yaml.
- Set DJANGO_SETTINGS_MODULE for tests to mpt_extension_sdk.runtime.djapp.conf.default in pyproject.toml.
- Cleaned up imports and typing in swo_playground:
  - swo_playground/api.py: replaced untyped imports with concrete imports, added targeted type ignores, removed root and healthcheck endpoints from public surface, minor docstring fix for process_order_validation.
  - swo_playground/events.py: fixed dataclasses import, consolidated imports, added logging around fulfillment, and invoke purchase_pipeline.run(client, context).
  - swo_playground/steps.py: removed type-ignore comments for imports and corrected docstring typos.
  - swo_playground/management/commands/hello.py: added @override to Command.handle.
- Tests updates:
  - tests/conftest.py: added MPTClient import, changed INSTALLED_APPS mutation to assignment, added mock_mpt_client fixture.
  - Added tests: tests/management/commands/test_hello.py and tests/test_apps.py.
  - tests/test_steps.py: refactored fixtures and tests to use mock_next_step and mock_mpt_client; updated Context construction and assertions.
  - tests/test_events.py: added test asserting purchase_pipeline.run is invoked and relevant log messages are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16890]: https://softwareone.atlassian.net/browse/MPT-16890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ