### PR TITLE
MPT-17854: add dependabot in ignore_usernames

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -52,7 +52,7 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
-    ignore_usernames: []
+    ignore_usernames: ["dependabot[bot]"]
     base_branches:
       - main
       - release/.*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17854](https://softwareone.atlassian.net/browse/MPT-17854)

- Updated `.coderabbit.yaml` to add `dependabot[bot]` to the `auto_review.ignore_usernames` list
- Excludes automated dependency updates from the CodeRabbit auto-review process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17854]: https://softwareone.atlassian.net/browse/MPT-17854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ