### PR TITLE
MPT-17883: add mpt tool make commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.py]
 indent_size = 4
+
+[{Makefile,*.mk}]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,8 @@ cython_debug/
 .ruff_cache
 .idea
 
+# Makefile
+make/local.mk
 
 # mpt-tool
 .migrations-state.json

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,11 @@
-.PHONY: bash build check check-all down format review run shell test help
+MK_FILES := $(sort $(wildcard make/*.mk))
+-include $(MK_FILES)
 
-DC = docker compose -f compose.yaml
+.DEFAULT_GOAL := help
+.PHONY: $(shell awk -F: '/^[a-zA-Z0-9_-]+:([^=]|$$)/ {print $$1}' $(MAKEFILE_LIST))
 
-help:
+require = $(if $(value $(1)),,$(error Missing required variable: $(1). Example: make $(MAKECMDGOALS) $(1)=<value>))
+
+help:  ## Show available commands
 	@echo "Available commands:"
-	@echo "  make bash             - Open a bash shell in the app container."
-	@echo "  make build            - Build images."
-	@echo "  make check            - Check code quality with ruff."
-	@echo "  make check-all        - Run checks and tests."
-	@echo "  make down             - Stop and remove containers."
-	@echo "  make format           - Format code."
-	@echo "  make review           - Check the code in the cli by running CodeRabbit."
-	@echo "  make run              - Run service."
-	@echo "  make shell            - Open Django shell."
-	@echo "  make test             - Run tests."
-	@echo "  make help             - Display this help message."
-
-bash:
-	  $(DC) run --rm -it app bash
-
-build:
-	  $(DC) build
-
-check:
-	  $(DC) run --rm app bash -c "ruff format --check . && ruff check . && flake8 . && uv lock --check"
-
-check-all: check test
-
-down:
-	  $(DC) down
-
-format:
-	  $(DC) run --rm app bash -c "ruff check --select I --fix . && ruff format ."
-
-review:
-	  coderabbit review --prompt-only
-
-run:
-	  $(DC) up
-
-shell:
-	  $(DC) run --rm -it app bash -c "swoext shell"
-
-test:
-	  $(DC) run --rm app pytest $(if $(args),$(args),.)
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  make %-22s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -21,19 +21,22 @@ Playground Extension with the SoftwareONE Marketplace
 
 ### Make targets overview
 
-Common development workflows are wrapped in the `makefile`:
+Common development workflows are wrapped in the `Makefile`. Run `make help` to see the list of available commands.
 
-- `make help` – list available commands
-- `make bash` – start the app container and open a bash shell
-- `make build` – build the application image for development
-- `make check` – run code quality checks (ruff, flake8, lockfile check)
-- `make check-all` – run checks and tests
-- `make format` – apply formatting and import fixes
-- `make down` – stop and remove containers
-- `make review` –  check the code in the cli by running CodeRabbit
-- `make run` – run the service
-- `make shell` – open a Django shell inside the running app container
-- `make test` – run the test suite with pytest
+### How the Makefile works
+
+The project uses a modular Makefile structure that organizes commands into logical groups:
+
+- **Main Makefile** (`Makefile`): Entry point that automatically includes all `.mk` files from the `make/` directory
+- **Modular includes** (`make/*.mk`): Commands are organized by category:
+  - `common.mk` - Core development commands (build, test, format, etc.)
+  - `repo.mk` - Repository management and dependency commands
+  - `migrations.mk` - Database migration commands (Only available in extension repositories)
+  - `external_tools.mk` - Integration with external tools
+
+
+You can extend the Makefile with your own custom commands creating a `local.mk` file inside make folder. This file is
+automatically ignored by git, so your personal commands won't affect other developers or appear in version control.
 
 ## Running tests
 
@@ -111,6 +114,19 @@ make check-all # run checks and tests
 make format    # auto-format code and imports
 make review    # check the code in the cli by running CodeRabbit
 make shell     # open a Django shell in the app container
+```
+
+### Migration commands
+
+The mpt-tool provides commands for managing database migrations:
+
+```bash
+make migrate-check                           # check migration status
+make migrate-data                            # run data migrations
+make migrate-schema                          # run schema migrations
+make migrate-list                            # list available migrations
+make migrate-new-data name=migration_id      # create a new data migration
+make migrate-new-schema name=migration_id    # create a new schema migration
 ```
 
 

--- a/make/common.mk
+++ b/make/common.mk
@@ -1,0 +1,29 @@
+DC = docker compose -f compose.yaml
+RUN = $(DC) run --rm app
+RUN_IT = $(DC) run --rm -it app
+
+bash:  ## Open a bash shell
+	$(RUN_IT) bash
+
+build:  ## Build images
+	$(DC) build
+
+check:  ## Check code quality with ruff
+	$(RUN) bash -c "ruff format --check . && ruff check . && flake8 . && uv lock --check"
+
+check-all:  check test ## Run checks and tests
+
+down:  ## Stop and remove containers
+	$(DC) down
+
+format:  ## Format code
+	$(RUN) bash -c "ruff check --select I --fix . && ruff format ."
+
+run:  ## Run service
+	$(DC) up
+
+shell:  ## Open Django shell
+	$(RUN_IT) bash -c "swoext shell"
+
+test:  ## Run test
+	$(RUN) pytest $(if $(args),$(args),.)

--- a/make/external_tools.mk
+++ b/make/external_tools.mk
@@ -1,0 +1,2 @@
+review:  ## Check the code in the cli by running CodeRabbit
+	coderabbit review --prompt-only

--- a/make/migrations.mk
+++ b/make/migrations.mk
@@ -1,0 +1,21 @@
+RUN_MIGRATE = $(RUN) mpt-service-cli migrate
+
+migrate-check: ## Check migration status
+	$(RUN_MIGRATE) --check
+
+migrate-data: ## Run data migrations
+	$(RUN_MIGRATE) --data
+
+migrate-schema: ## Run schema migrations
+	$(RUN_MIGRATE) --schema
+
+migrate-list: ## List migrations with the status
+	$(RUN_MIGRATE) --list
+
+migrate-new-data: ## Create new data migration (name=<migration_id>)
+	$(call require,name)
+	$(RUN_MIGRATE) --new-data $(name)
+
+migrate-new-schema: ## Create new schema migration (name=<migration_id>)
+	$(call require,name)
+	$(RUN_MIGRATE) --new-schema $(name)

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -1,0 +1,1 @@
+## Add repo-specific targets here. Do not modify the shared *.mk files.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-17883](https://softwareone.atlassian.net/browse/MPT-17883)

- Refactored Makefile into a modular structure with dynamic help generation via awk
- Set `.DEFAULT_GOAL` to `help` for better developer experience
- Added `.editorconfig` rules for Makefile-specific formatting (tab indentation)
- Created `make/common.mk` with docker-compose shortcuts for development workflows (bash, build, check, check-all, down, format, run, shell, test)
- Created `make/external_tools.mk` with code review target (`coderabbit review --prompt-only`)
- Created `make/migrations.mk` with migration command targets (migrate-check, migrate-data, migrate-schema, migrate-list, migrate-new-data, migrate-new-schema)
- Created `make/repo.mk` as placeholder for repository-specific targets
- Updated README.md with documentation on modular Makefile structure and new migration commands section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17883]: https://softwareone.atlassian.net/browse/MPT-17883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ