### PR TITLE
MPT-17833: add uv commands to makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,25 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 WORKDIR /extension
 
-RUN uv venv /opt/venv
-
-ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=/opt/venv/bin:$PATH
+ENV UV_LINK_MODE=copy
+ENV PATH=/extension/.venv/bin:$PATH
 
 FROM base AS build
 
 COPY . .
 
-RUN uv sync --frozen --no-cache --all-groups --active
+RUN uv sync --frozen --no-cache --no-dev
 
 FROM build AS dev
 
+RUN uv sync --frozen --no-cache --dev
 
 CMD ["swoext", "run"]
 
 FROM build AS prod
 
 RUN groupadd -r appuser && useradd -r -g appuser appuser && \
-    chown -R appuser:appuser /extension /opt/venv
+    chown -R appuser:appuser /extension
 
 USER appuser
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Playground Extension with the SoftwareONE Marketplace
 
 - Docker and Docker Compose plugin (`docker compose` CLI)
 - `make`
-- Valid `.env` file
-- Adobe credentials and authorizations JSON files in the project root
 - [CodeRabbit CLI](https://www.coderabbit.ai/cli) (optional. Used for running review check locally)
 
 
@@ -38,45 +36,61 @@ The project uses a modular Makefile structure that organizes commands into logic
 You can extend the Makefile with your own custom commands creating a `local.mk` file inside make folder. This file is
 automatically ignored by git, so your personal commands won't affect other developers or appear in version control.
 
-## Running tests
 
-Tests run inside Docker using the dev configuration.
+### Setup
 
-Run the full test suite:
+Follow these steps to set up the development environment:
 
-```bash
-make test
-```
-
-Pass additional arguments to pytest using the `args` variable:
+#### 1. Clone the repository
 
 ```bash
-make test args="-k test_playground -vv"
-make test args="tests/test_steps.py"
+git clone <repository-url>
+```
+```bash
+cd swo-extension-playground
 ```
 
-## Running the service
+#### 2. Create environment configuration
 
-### 1. Configuration files
-
-In the project root, create and configure the following files.
-
-#### Environment files
-
-Start from the sample file:
+Copy the sample environment file and update it with your values:
 
 ```bash
 cp .env.sample .env
 ```
 
-Update `.env` with your values. This file is used by all Docker Compose configurations and the `make run` target.
+Edit the `.env` file with your actual configuration values. See the [Configuration](#configuration) section for details on available variables.
 
-### 2. Running
+#### 3. Build the Docker images
 
-Run the service against real SoftwareONE Marketplace APIs. It uses `compose.yaml` and reads environment from `.env`.
+Build the development environment:
 
-Ensure:
-- `.env` is populated with real endpoints and tokens.
+```bash
+make build
+```
+
+This will create the Docker images with all required dependencies and the virtualenv.
+
+> **Note on local development without Docker:**
+> Docker is the primary development environment, the default setup and Makefile commands are designed to work only with Docker.
+> `.venv` is used as the default virtualenv, and the project folder is mounted as a volume in docker-compose.
+> If you want to run the project locally (without Docker), use a different virtualenv name to avoid confusion
+> (e.g., `.venv_local`, `env/`, `venv`, `ENV/` - it will be ignored from docker and gitignore)
+> You can also set the `UV_PROJECT_ENVIRONMENT` in your .env file to point `uv` to your local environment.
+
+#### 4. Verify the setup
+
+Run the test suite to ensure everything is configured correctly:
+
+```bash
+make test
+```
+
+You're now ready to start developing! See [Running the service](#running-the-service) for next steps.
+
+
+## Running the service
+
+Before running, ensure your `.env` file is populated with real endpoints and tokens.
 
 Start the app:
 

--- a/make/common.mk
+++ b/make/common.mk
@@ -7,6 +7,7 @@ bash:  ## Open a bash shell
 
 build:  ## Build images
 	$(DC) build
+	$(RUN) uv sync
 
 check:  ## Check code quality with ruff
 	$(RUN) bash -c "ruff format --check . && ruff check . && flake8 . && uv lock --check"
@@ -27,3 +28,17 @@ shell:  ## Open Django shell
 
 test:  ## Run test
 	$(RUN) pytest $(if $(args),$(args),.)
+
+uv-add: ## Add a production dependency (pkg=<package_name>)
+	$(call require,pkg)
+	$(RUN) bash -c "uv add $(pkg)"
+	$(MAKE) build
+
+uv-add-dev: ## Add a dev dependency (pkg=<package_name>)
+	$(call require,pkg)
+	$(RUN) bash -c "uv add --dev $(pkg)"
+	$(MAKE) build
+
+uv-upgrade: ## Upgrade all packages or a specific package (use pkg="package_name" to target one)
+	$(RUN) bash -c "uv lock $(if $(pkg),--upgrade-package $(pkg),--upgrade) && uv sync"
+	$(MAKE) build

--- a/make/local.mk
+++ b/make/local.mk
@@ -1,0 +1,1 @@
+## Add repo-specific targets here. Do not modify the shared *.mk files.

--- a/make/local.mk
+++ b/make/local.mk
@@ -1,1 +1,0 @@
-## Add repo-specific targets here. Do not modify the shared *.mk files.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-17833](https://softwareone.atlassian.net/browse/MPT-17833)

## Release Notes

- Makefile / make/common.mk
  - Added dependency management targets:
    - `uv-add` — add a production dependency (requires pkg)
    - `uv-add-dev` — add a dev dependency (requires pkg)
    - `uv-upgrade` — upgrade all or a specific dependency (use pkg="name")
  - Build flow updated: `make build`/build target now runs `uv sync`.

- Dockerfile
  - Use UV_LINK_MODE=copy and set PATH to /extension/.venv/bin
  - Updated uv sync invocations:
    - build stage: `uv sync --frozen --no-cache --no-dev`
    - dev stage: added `uv sync --frozen --no-cache --dev`
  - Prod stage: restrict chown to /extension and keep USER appuser
  - Final image: remove tests/ and set CMD to `swoext run --no-color`

- Documentation
  - README expanded with a detailed Setup section, development workflow, build and verification steps, environment configuration guidance, and developer utilities overview
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17833]: https://softwareone.atlassian.net/browse/MPT-17833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ