### PR TITLE
MPT-17672: allow to pass args to make review command

### DIFF
--- a/make/external_tools.mk
+++ b/make/external_tools.mk
@@ -1,2 +1,2 @@
-review:  ## Check the code in the cli by running CodeRabbit
-	coderabbit review --prompt-only
+review:  ## Run CodeRabbit code review in interactive mode. Pass args=<options> to override or include more options
+	coderabbit review $(args)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17672](https://softwareone.atlassian.net/browse/MPT-17672)

### Changes

- Modified the `review` target in `make/external_tools.mk` to accept dynamic arguments instead of using a hardcoded `--prompt-only` flag
- Updated the target's description to indicate interactive mode with support for passing custom arguments via `args=<options>`
- The command now forwards flexible arguments as `coderabbit review $(args)` to allow for better customization of the code review process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17672]: https://softwareone.atlassian.net/browse/MPT-17672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ