### PR TITLE
MPT-20117 Add baseline repository documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,6 @@ MPT_TOOL_STORAGE_TYPE=local
 MPT_TOOL_STORAGE_AIRTABLE_API_KEY=<fake-airtable-api-key>
 MPT_TOOL_STORAGE_AIRTABLE_BASE_ID=<fake-storage-airtable-base-id>
 MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME=<fake-storage-airtable-table-name>
+# Optional for local development. Set in environments where telemetry is enabled.
+# APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=<instrumentation-key>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/;LiveEndpoint=https://<region>.livediagnostics.monitor.azure.com/
+# OTEL_SERVICE_NAME=Swo.Extensions.<ServiceName>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Read the repository in this order:
+
+1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
+2. [docs/architecture.md](docs/architecture.md) for the template architecture placeholder and future design notes.
+3. [docs/local-development.md](docs/local-development.md) for local setup and service startup.
+4. [docs/deployment.md](docs/deployment.md) for configuration and runtime parameters.
+5. [docs/contributing.md](docs/contributing.md) for the repository workflow and expected developer commands.
+6. [docs/testing.md](docs/testing.md) before changing code or tests.
+7. [docs/migrations.md](docs/migrations.md) when a task mentions schema or data migrations.
+8. [docs/documentation.md](docs/documentation.md) when changing repository documentation.
+
+Then inspect the code paths relevant to the task:
+
+- [`swo_playground/apps.py`](swo_playground/apps.py): Django app registration and extension entry point
+- [`swo_playground/api.py`](swo_playground/api.py): HTTP API and validation flow
+- [`swo_playground/events.py`](swo_playground/events.py): event listeners
+- [`swo_playground/steps.py`](swo_playground/steps.py): fulfillment pipeline steps
+- [`tests/`](tests/): test coverage examples and fixtures
+- [`make/`](make/): canonical commands used by the repository
+
+Operational guidance:
+
+- Prefer the documented `make` targets over ad hoc Docker commands.
+- Treat Docker as the default local execution model for this repository.
+- Keep documentation modular. Update the specific file in `docs/` instead of expanding `README.md` into a full manual.
+- Do not invent undocumented migration behavior. If the codebase has no concrete migration examples, document the current constraint and keep changes aligned with `mpt-service-cli migrate`.
+- For shared meaning of common `make` targets and validation flow, prefer the shared knowledge documents instead of inferring local semantics from target names alone.

--- a/README.md
+++ b/README.md
@@ -1,179 +1,49 @@
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=softwareone-platform_swo-extension-playground&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=softwareone-platform_swo-extension-playground)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=softwareone-platform_swo-extension-playground&metric=coverage)](https://sonarcloud.io/summary/new_code?id=softwareone-platform_swo-extension-playground)
+# SWO Extension Playground
 
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+`swo-extension-playground` is a minimal SoftwareOne Marketplace extension built on top of `mpt-extension-sdk` and `mpt-tool`.
 
-# SoftwareONE Extension playground
+It is primarily a playground repository: it shows the baseline extension shape, a simple validation API endpoint, an event listener, a small fulfillment pipeline, and the development workflow used by extension repositories in this ecosystem.
 
-Playground Extension with the SoftwareONE Marketplace
+## Repository Layout
 
+- `swo_playground/` contains the extension package.
+- `tests/` contains the pytest suite.
+- `make/*.mk` contains the repository make targets.
+- `compose.yaml` defines the local Docker-based development environment.
 
-## Getting started
+## Quick Start
 
-### Prerequisites
+Prerequisites:
 
-- Docker and Docker Compose plugin (`docker compose` CLI)
+- Docker with the `docker compose` plugin
 - `make`
-- [CodeRabbit CLI](https://www.coderabbit.ai/cli) (optional. Used for running review check locally)
 
-
-### Make targets overview
-
-Common development workflows are wrapped in the `Makefile`. Run `make help` to see the list of available commands.
-
-### How the Makefile works
-
-The project uses a modular Makefile structure that organizes commands into logical groups:
-
-- **Main Makefile** (`Makefile`): Entry point that automatically includes all `.mk` files from the `make/` directory
-- **Modular includes** (`make/*.mk`): Commands are organized by category:
-  - `common.mk` - Core development commands (build, test, format, etc.)
-  - `repo.mk` - Repository management and dependency commands
-  - `migrations.mk` - Database migration commands (Only available in extension repositories)
-  - `external_tools.mk` - Integration with external tools
-
-
-You can extend the Makefile with your own custom commands creating a `local.mk` file inside make folder. This file is
-automatically ignored by git, so your personal commands won't affect other developers or appear in version control.
-
-
-### Setup
-
-Follow these steps to set up the development environment:
-
-#### 1. Clone the repository
-
-```bash
-git clone <repository-url>
-```
-```bash
-cd swo-extension-playground
-```
-
-#### 2. Create environment configuration
-
-Copy the sample environment file and update it with your values:
-
-```bash
-cp .env.sample .env
-```
-
-Edit the `.env` file with your actual configuration values. See the [Configuration](#configuration) section for details on available variables.
-
-#### 3. Build the Docker images
-
-Build the development environment:
+Recommended setup:
 
 ```bash
 make build
-```
-
-This will create the Docker images with all required dependencies and the virtualenv.
-
-> **Note on local development without Docker:**
-> Docker is the primary development environment, the default setup and Makefile commands are designed to work only with Docker.
-> `.venv` is used as the default virtualenv, and the project folder is mounted as a volume in docker-compose.
-> If you want to run the project locally (without Docker), use a different virtualenv name to avoid confusion
-> (e.g., `.venv_local`, `env/`, `venv`, `ENV/` - it will be ignored from docker and gitignore)
-> You can also set the `UV_PROJECT_ENVIRONMENT` in your .env file to point `uv` to your local environment.
-
-#### 4. Verify the setup
-
-Run the test suite to ensure everything is configured correctly:
-
-```bash
 make test
-```
-
-You're now ready to start developing! See [Running the service](#running-the-service) for next steps.
-
-
-## Running the service
-
-Before running, ensure your `.env` file is populated with real endpoints and tokens.
-
-Start the app:
-
-```bash
 make run
 ```
 
-The service will be available at `http://localhost:8080`.
+The application runs on `http://localhost:8080`.
 
-Example `.env` snippet for real services:
+## Common Commands
 
-```env
-EXT_WEBHOOKS_SECRETS={"PRD-1111-1111": "<webhook-secret-for-product>", "PRD-2222-2222": "<webhook-secret-for-product>"}
-MPT_API_BASE_URL=https://api.s1.show
-MPT_API_TOKEN=c0fdafd7-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-MPT_INITIALIZER="swo_playground.initializer.initialize"
-MPT_KEY_VAULT_NAME=""
-MPT_ORDERS_API_POLLING_INTERVAL_SECS=120
-MPT_PORTAL_BASE_URL=https://portal.s1.show
-MPT_PRODUCTS_IDS=PRD-1111-1111,PRD-2222-2222
-```
+Shared meaning of common make targets is documented in:
 
-`MPT_PRODUCTS_IDS` is a comma-separated list of SWO Marketplace Product identifiers.
-For each product ID in the `MPT_PRODUCTS_IDS` list, define the corresponding entry in the `EXT_WEBHOOKS_SECRETS` JSON using the product ID as the key.
+- [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+- [knowledge/build-and-checks.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/build-and-checks.md)
 
+## Documentation
 
-## Developer utilities
+- [AGENTS.md](AGENTS.md): entry point for AI agents
+- [docs/architecture.md](docs/architecture.md): architecture placeholder for future repository-specific design
+- [docs/contributing.md](docs/contributing.md): repository-specific development workflow
+- [docs/local-development.md](docs/local-development.md): local setup and service startup
+- [docs/deployment.md](docs/deployment.md): runtime configuration and deployment-facing settings
+- [docs/testing.md](docs/testing.md): testing strategy and commands
+- [docs/migrations.md](docs/migrations.md): migration workflow and current constraints
+- [docs/documentation.md](docs/documentation.md): repository documentation rules
 
-Useful helper targets during development:
-
-```bash
-make bash      # open a bash shell in the app container
-make check     # run ruff, flake8, and lockfile checks
-make check-all # run checks and tests
-make format    # auto-format code and imports
-make review    # check the code in the cli by running CodeRabbit
-make shell     # open a Django shell in the app container
-```
-
-### Migration commands
-
-The mpt-tool provides commands for managing database migrations:
-
-```bash
-make migrate-check                           # check migration status
-make migrate-data                            # run data migrations
-make migrate-schema                          # run schema migrations
-make migrate-list                            # list available migrations
-make migrate-new-data name=migration_id      # create a new data migration
-make migrate-new-schema name=migration_id    # create a new schema migration
-```
-
-
-# Configuration
-
-The following environment variables are typically set in `.env`. Docker Compose reads them when using the Make targets described above.
-
-## Application
-
-| Environment Variable                   | Default                 | Example                                   | Description                                                                               |
-|----------------------------------------|-------------------------|-------------------------------------------|-------------------------------------------------------------------------------------------|
-| `EXT_WEBHOOKS_SECRETS`                 | -                       | {"PRD-1111-1111": "123qweasd3432234"}     | Webhook secret of the Draft validation Webhook in SoftwareONE Marketplace for the product |
-| `MPT_API_BASE_URL`                     | `http://localhost:8000` | `https://api.platform.softwareone.com`    | SoftwareONE Marketplace API URL                                                           |
-| `MPT_API_TOKEN`                        | -                       | eyJhbGciOiJSUzI1N...                      | SoftwareONE Marketplace API Token                                                         |
-| `MPT_INITIALIZER`                      | -                       | swo_playground.initializer.initialize     | Initializer function                                                                      |
-| `MPT_KEY_VAULT_NAME`                   | mpt-key-vault           | swo-playground-kv                         | Key Vault name                                                                            |
-| `MPT_PRODUCTS_IDS`                     | PRD-1111-1111           | PRD-1234-1234,PRD-4321-4321               | Comma-separated list of SoftwareONE Marketplace Product ID                                |
-| `MPT_PORTAL_BASE_URL`                  | `http://localhost:8000` | `https://portal.softwareone.com`          | SoftwareONE Marketplace Portal URL                                                        |
-| `MPT_TOOL_STORAGE_TYPE`                | `local`                 | `airtable`                                | Storage type for MPT tools (local or airtable)                                            |
-| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY`    | -                       | patXXXXXXXXXXXXXX                         | Airtable API key for MPT tool storage (required when storage type is airtable)            |
-| `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID`    | -                       | appXXXXXXXXXXXXXX                         | Airtable base ID for MPT tool storage (required when storage type is airtable)            |
-| `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` | -                       | MigrationTracking                         | Airtable table name for MPT tool storage (required when storage type is airtable)         |
-
-
-### Azure AppInsights
-
-| Environment Variable                    | Default                            | Example                                                                                                                                                                                               | Description                                                                                                   |
-|-----------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | -                                  | `InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/` | Azure Application Insights connection string                                                                  |
-| `OTEL_SERVICE_NAME`                     | -                                  | Swo.Extensions.Playground                                                                                                                                                                             | Service name that is visible in the AppInsights logs                                                          |
-
-### Other
-
-| Environment Variable                   | Default | Example | Description                                                          |
-|----------------------------------------|---------|---------|----------------------------------------------------------------------|
-| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | 120     | 60      | Orders polling interval from the Software Marketplace API in seconds |
+Keep repository-specific workflow details in the documents under [`docs/`](docs/), not in this file.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,23 @@
+# Architecture
+
+Keep this document focused on actual architecture decisions for the repository.
+
+If the repository does not yet have stable architectural decisions, keep this file short and avoid speculative descriptions.
+
+## What To Document Here
+
+When architecture details become relevant, document:
+
+- the main runtime components
+- repository boundaries and responsibility split
+- extension entry points
+- data flow between API handlers, event listeners, pipelines, and external services
+- any persistence model and migration boundaries
+- important design decisions or tradeoffs
+
+## Guidance
+
+- Keep this file minimal until there is real architecture to describe.
+- Avoid fictional or speculative architecture.
+- Put workflow details in the other topic-specific documents under `docs/`.
+- Update this file when the repository gains stable components or non-trivial design rules.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,60 @@
+# Contributing
+
+This document describes repository-specific contribution rules.
+
+Shared rules live in `mpt-extension-skills/standards` and should not be duplicated here:
+
+- documentation standard: [documentation.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/documentation.md)
+- makefile structure: [makefiles.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/makefiles.md)
+- commit message rules: [commit-messages.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/commit-messages.md)
+- dependency management: [packages-and-dependencies.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/packages-and-dependencies.md)
+- extension design guidance: [extensions-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-best-practices.md)
+- pull request rules: [pull-requests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/pull-requests.md)
+- Python coding conventions: [python-coding.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/python-coding.md)
+
+Shared operational knowledge also lives there:
+
+- build and validation flow: [knowledge/build-and-checks.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/build-and-checks.md)
+- common make target meanings: [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+## Development Model
+
+The default development environment is Docker-based.
+
+- Use `make build` to build the image and sync dependencies with `uv`.
+- Use `make bash` or `make shell` when you need an interactive container session.
+
+If the repository supports a local-only workflow outside Docker, document it explicitly in [docs/local-development.md](local-development.md). Otherwise, treat Docker as the default path.
+
+For service startup and local environment expectations, use [docs/local-development.md](local-development.md).
+
+## Code Changes
+
+Repository-specific expectations:
+
+- Keep production code in the repository's main application modules.
+- Keep tests under `tests/`, mirroring the production module structure where practical.
+- Prefer small, explicit changes that preserve the repository's intended scope.
+- When adding a new extension behavior, update or add tests in the same change.
+
+## Validation Before Review
+
+Follow the shared build-and-checks knowledge for the general validation flow.
+
+Repository-specific command entrypoints before review:
+
+```bash
+make check
+make test
+```
+
+Use `make check-all` when the repository exposes it and you want the combined validation workflow.
+
+See [docs/testing.md](testing.md) for repository-specific testing expectations.
+
+## Documentation Changes
+
+When changing repository docs:
+
+- Update [docs/local-development.md](local-development.md), [docs/deployment.md](deployment.md), [docs/testing.md](testing.md), [docs/migrations.md](migrations.md), or [docs/documentation.md](documentation.md) when the corresponding workflow changes.
+- Follow the shared documentation standard for structure and naming.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,64 @@
+# Deployment
+
+This document describes runtime configuration.
+
+It is the source of truth for environment parameters referenced by local development and deployment flows.
+
+## Configuration Source
+
+The repository runtime expects environment variables, typically provided through `.env` for local Docker Compose usage.
+
+Local setup instructions live in [docs/local-development.md](local-development.md).
+
+## Core Application Settings
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `EXT_WEBHOOKS_SECRETS` | - | `{"PRD-1111-1111": "123qweasd3432234"}` | Webhook secret keyed by Marketplace product id |
+| `MPT_API_BASE_URL` | `http://localhost:8000` | `https://api.platform.softwareone.com` | SoftwareOne Marketplace API URL |
+| `MPT_API_TOKEN` | - | `eyJhbGciOiJSUzI1N...` | SoftwareOne Marketplace API token |
+| `MPT_INITIALIZER` | - | `<package>.initializer.initialize` | Optional initializer function |
+| `MPT_KEY_VAULT_NAME` | `mpt-key-vault` | `<key-vault-name>` | Key Vault name |
+| `MPT_PRODUCTS_IDS` | `PRD-1111-1111` | `PRD-1234-1234,PRD-4321-4321` | Comma-separated list of Marketplace product ids |
+| `MPT_PORTAL_BASE_URL` | `http://localhost:8000` | `https://portal.softwareone.com` | SoftwareOne Marketplace Portal URL |
+| `MPT_TOOL_STORAGE_TYPE` | `local` | `airtable` | Storage type for MPT tools |
+| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXXXXXXXX` | Airtable API key when Airtable storage is enabled |
+| `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID` | - | `appXXXXXXXXXXXXXX` | Airtable base id when Airtable storage is enabled |
+| `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` | - | `MigrationTracking` | Airtable table name when Airtable storage is enabled |
+| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | `120` | `60` | Order polling interval in seconds |
+
+## AppInsights Settings
+
+`APPLICATIONINSIGHTS_CONNECTION_STRING` and `OTEL_SERVICE_NAME` are optional for local development unless local telemetry is explicitly enabled. In production or telemetry-enabled environments, set both variables together.
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | - | `InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/` | Azure Application Insights connection string |
+| `OTEL_SERVICE_NAME` | - | `Swo.Extensions.<ServiceName>` | Service name shown in telemetry |
+
+## Local Example
+
+Example `.env` snippet:
+
+```env
+EXT_WEBHOOKS_SECRETS={"PRD-1111-1111": "<webhook-secret-for-product>", "PRD-2222-2222": "<webhook-secret-for-product>"}
+MPT_API_BASE_URL=https://api.s1.show
+MPT_API_TOKEN=c0fdafd7-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+MPT_INITIALIZER="<package>.initializer.initialize"
+MPT_KEY_VAULT_NAME=""
+MPT_ORDERS_API_POLLING_INTERVAL_SECS=120
+MPT_PORTAL_BASE_URL=https://portal.s1.show
+MPT_PRODUCTS_IDS=PRD-1111-1111,PRD-2222-2222
+MPT_TOOL_STORAGE_TYPE=local
+MPT_TOOL_STORAGE_AIRTABLE_API_KEY=<airtable-api-key>
+MPT_TOOL_STORAGE_AIRTABLE_BASE_ID=<airtable-base-id>
+MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME=<airtable-table-name>
+```
+
+`MPT_PRODUCTS_IDS` is a comma-separated list of Marketplace product identifiers.
+
+For each product id in `MPT_PRODUCTS_IDS`, define the corresponding secret in `EXT_WEBHOOKS_SECRETS` using the product id as the key.
+
+The `MPT_TOOL_STORAGE_*` variables mirror the storage configuration documented in `mpt-tool`. When `MPT_TOOL_STORAGE_TYPE=local`, the Airtable variables may remain unset locally. When `MPT_TOOL_STORAGE_TYPE=airtable`, set `MPT_TOOL_STORAGE_AIRTABLE_API_KEY`, `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID`, and `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` together.
+
+Adjust examples in this file to match the actual package names, service names, endpoints, and integrations used by the target repository.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,5 @@
+# Documentation
+
+Repository documentation rules are defined in the shared standard:
+
+- [mpt-extension-skills/standards/documentation.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/documentation.md)

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,48 @@
+# Local Development
+
+This document describes how to run the repository locally in the supported Docker workflow.
+
+## Prerequisites
+
+- Docker with the `docker compose` plugin
+- `make`
+
+## Setup
+
+Build the development image and install dependencies:
+
+```bash
+make build
+```
+
+## Running the Service
+
+Start the service with Docker Compose:
+
+```bash
+make run
+```
+
+The service is exposed on `http://localhost:8080`.
+
+Useful helper commands:
+
+```bash
+make bash
+make shell
+make down
+```
+
+## Environment Parameters
+
+Local startup requires an `.env` file consumed by Docker Compose.
+
+The parameter reference lives in [docs/deployment.md](deployment.md). Use that document for:
+
+- required and optional environment variables
+- example values
+- runtime-specific notes for Marketplace integration, webhook secrets, Airtable, and AppInsights
+
+Do not duplicate the parameter reference in this file.
+
+Adjust startup commands, URLs, and helper commands in this file if the target repository differs from the defaults documented here.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,24 @@
+# Migrations
+
+Use this document only for migration details that are specific to the repository.
+
+Shared migration knowledge lives in:
+
+- [knowledge/migrations.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/migrations.md)
+- [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+If the repository does not yet have repository-specific migration rules, keep this file short and rely on the shared migration knowledge above.
+
+## What To Add Here
+
+Add repository-specific migration details only when they exist, for example:
+
+- where migration files live
+- which migration commands are actually used in this repository
+- required execution order or rollout rules
+- operational constraints or safety checks
+- differences from the shared migration knowledge
+
+## Documentation Rule
+
+When repository-specific migration behavior is introduced or changed, update this document in the same change.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,71 @@
+# Testing
+
+Shared unit-test rules live in [unittests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/unittests.md).
+
+Shared build and target knowledge also applies:
+
+- [knowledge/build-and-checks.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/build-and-checks.md)
+- [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+This file documents only repository-specific testing behavior.
+
+## Test Scope
+
+Document the areas that the repository tests currently cover. Typical examples:
+
+- extension app registration
+- HTTP validation behavior
+- event handling
+- fulfillment pipeline steps
+- management command behavior
+
+Document representative test locations here when the repository has stable test coverage patterns.
+
+## Commands
+
+Use the repository make targets:
+
+```bash
+make test
+make check
+make check-all
+```
+
+Repository command mapping:
+
+- `make test` runs `pytest`
+- `make check` runs formatting, linting, and lockfile validation
+- `make check-all` runs both checks and tests
+
+## Pytest Configuration
+
+Document the repository-specific test settings from [`pyproject.toml`](../pyproject.toml), for example:
+
+- tests run from `tests/`
+- coverage is collected for the main application package
+- `DJANGO_SETTINGS_MODULE` is set to `mpt_extension_sdk.runtime.djapp.conf.default`
+- `pythonpath` includes the repository root
+
+## Writing Tests
+
+Repository-specific guidance:
+
+- Use fixtures from [`tests/conftest.py`](../tests/conftest.py) where possible.
+- Register the extension app through shared fixtures instead of redefining Django settings in each test.
+- Mock external Marketplace SDK calls rather than calling real services.
+- Keep tests focused on the behavior of the extension layer, not on internals of `mpt-extension-sdk` itself.
+- Follow the shared unit-test standard for AAA structure, parametrization, mocking rules, deterministic behavior, and coverage expectations.
+
+Remove or replace any example paths in this file once the repository has its own stable test layout.
+
+## When to Add Tests
+
+Add or update tests when a change modifies:
+
+- API request handling
+- event processing
+- pipeline step behavior
+- command output
+- dependency wiring in the extension app
+
+If a change only affects documentation, tests are not required.


### PR DESCRIPTION
## Summary
- add baseline repository documentation files for humans and AI agents
- align local docs with shared standards and shared knowledge
- keep docs portable by using relative links and reducing repository-specific duplication

## Testing
- not run (documentation-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20117](https://softwareone.atlassian.net/browse/MPT-20117)

- Added AGENTS.md describing recommended doc reading order, key code-paths to inspect, and operational guidance (prefer documented make targets, Docker-first local execution, keep docs modular).
- Rewrote README.md to a concise project overview with repository layout, quick start (Docker + make build), common commands, and links to docs/ and AGENTS.md (removed long-form setup and environment tables).
- Added docs/architecture.md with guidance for capturing stable architecture decisions and categories to document (runtime components, boundaries, extension entry points, data flow, persistence/migrations, key decisions).
- Added docs/contributing.md defining contribution rules, Docker-based dev model (make build, make bash/shell), testing expectations, and pre-review validation steps (make check, make test).
- Added docs/deployment.md as the source of truth for runtime environment variables (webhook secrets, Marketplace integration, Key Vault, product IDs, tool storage settings, polling interval, telemetry/AppInsights/OTEL) with concrete .env examples and conditional variable requirements.
- Added docs/documentation.md linking to shared documentation standards.
- Added docs/local-development.md documenting Docker Compose local workflow, prerequisites, build/run instructions, helper targets, and pointer to docs/deployment.md for env details.
- Added docs/migrations.md defining the repository-specific migration documentation scope and linking to shared migration guidance.
- Added docs/testing.md describing test scope, Makefile test/check targets, pytest guidance, and repository test conventions (fixtures, mocking, when to add/update tests).
- Updated .env.sample to include commented telemetry variables: APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20117]: https://softwareone.atlassian.net/browse/MPT-20117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ