### PR TITLE
MPT-20117 Thin Copilot Instructions Adapter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,43 +1,5 @@
----
-description: 'Python coding conventions and guidelines'
-applyTo: '**/*.py'
----
+# Copilot Instructions
 
-# Python Coding Conventions
+Use [AGENTS.md](../AGENTS.md) as the main repository guide.
 
-## General Instructions
-- All configuration **must be provided via environment variables**.
-- Do not hardcode configuration values.
-- Write maintainable, readable, and predictable code.
-- In `pyproject.toml`:
-  - Use `*` for **minor versions only**
-    ✅ `django==4.2.*`
-    ❌ `django==^4.2.2`
-
-- Use consistent naming conventions and follow language-specific best practices.
-
-## Python Instructions
-- Use type annotations (PEP 484) - except in the `tests/` folder.
-- All public functions, methods, and classes **must include [Google-style docstrings](https://google.github.io/styleguide/pyguide.html)**.
-- **Do not add inline comments**; rely on clear code and docstrings instead.
-- Function and variable names must be explicit and intention-revealing.
-- `pyproject.toml` is the source of truth for code quality rules. Generated code must not violate any configured rules.
-- **ruff** is the primary linter for general Python style and best practices.
-- **flake8** is used exclusively to run:
-  - `wemake-python-styleguide` - Enforces strict Python coding standards ([docs](https://wemake-python-styleguide.readthedocs.io/en/latest/))
-  - `flake8-aaa` - Validates the AAA pattern in tests
-- Follow PEP 8 unless explicitly overridden by ruff.
-- Prefer simple, explicit code over clever or compact implementations.
-
-## Testing
-- Use pytest only.
-- Tests must be written as **functions**, not classes.
-- Test files and functions must use the `test_` prefix.
-- Follow ***AAA(Arrange - Act - Assert)*** strictly. See the [flake8-aaa documentation](https://flake8-aaa.readthedocs.io/en/stable/index.html).
-- Do **not** use `if` statements or branching logic inside tests.
-- Prefer fixtures over mocks whenever possible.
-- Avoid duplicating test logic; extract shared setup into fixtures.
-- Use `mocker` only when mocking is unavoidable.
-- Never use `unittest.mock` directly.
-- Always use `spec` or `autospec` when mocking.
-- Use `@pytest.mark.parametrize` tests when testing permutations of the same behavior.
+Do not duplicate repository policy in this file. Keep tool-specific instructions here only when GitHub Copilot requires behavior that is not already covered by [AGENTS.md](../AGENTS.md).


### PR DESCRIPTION
## Summary
- reduce .github/copilot-instructions.md to a thin adapter that points to AGENTS.md
- keep repository policy in the main documentation entry points instead of duplicating it in tool-specific instructions
- rebase the branch on the latest main before opening this PR

## Testing
- not run (documentation-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20117](https://softwareone.atlassian.net/browse/MPT-20117)

- Reduced `.github/copilot-instructions.md` to a thin adapter that references `AGENTS.md` as the main repository guide
- Removed duplicated Python coding conventions and testing guidelines from the Copilot-specific instructions file
- Eliminated detailed rules for environment variables, version pinning, docstrings, type annotations, testing patterns, and linting configurations
- Kept the principle of avoiding repository policy duplication in tool-specific files while preserving Copilot-specific guidance where necessary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20117]: https://softwareone.atlassian.net/browse/MPT-20117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ