### PR TITLE
MPT-20397 clarify documentation reading order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,15 @@
 # AGENTS.md
 
-Read the repository in this order:
+Working protocol for any task in this repository:
+
+1. Start with `AGENTS.md`.
+2. Identify the task type and select only the local repository files that are relevant to that task.
+3. Read only those relevant local files before making changes.
+4. If any selected local file references shared standards or shared operational guidance that are relevant to the same task, read those shared documents too before proceeding.
+5. Treat repository-local documents as repository-specific additions, restrictions, or overrides to shared guidance.
+6. If a repository-local rule conflicts with a shared rule, the local repository rule takes precedence.
+
+After you start with `AGENTS.md` and identify the files relevant to the task, when applicable, read the repository in this order:
 
 1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
 2. [docs/architecture.md](docs/architecture.md) for the template architecture placeholder and future design notes.


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary
- update `AGENTS.md` with an explicit task-based documentation reading protocol
- require reading only the local repository files relevant to the current task before making changes
- require reading referenced shared standards or shared operational guidance when those references are relevant to the same task

## Testing
- `make check-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20397](https://softwareone.atlassian.net/browse/MPT-20397)

- Added "Working protocol for any task in this repository" to AGENTS.md establishing a task-scoped documentation reading workflow
- Requires agents to start with AGENTS.md and identify the task type before reading other files
- Requires reading only the local repository files relevant to the identified task
- When referenced and relevant, requires reading shared standards or shared operational guidance in addition to local files
- States repository-local documents act as additions/restrictions/overrides and take precedence over conflicting shared guidance
- Preserves the existing ordered reading list (README, docs/*, then code paths) after relevant files are identified
- Testing step: run `make check-all`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20397]: https://softwareone.atlassian.net/browse/MPT-20397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ