### PR TITLE
MPT-20397 simplify AGENTS entrypoint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,13 @@
 
 Working protocol for any task in this repository:
 
-1. Start with `AGENTS.md`.
-2. Identify the task type and select only the local repository files that are relevant to that task.
-3. Read only those relevant local files before making changes.
-4. If any selected local file references shared standards or shared operational guidance that are relevant to the same task, read those shared documents too before proceeding.
-5. Treat repository-local documents as repository-specific additions, restrictions, or overrides to shared guidance.
-6. If a repository-local rule conflicts with a shared rule, the local repository rule takes precedence.
+1. Identify the task type and select only the local repository files that are relevant to that task.
+2. Read only those relevant local files before making changes.
+3. If any selected local file references shared standards or shared operational guidance that are relevant to the same task, read those shared documents too before proceeding.
+4. Treat repository-local documents as repository-specific additions, restrictions, or overrides to shared guidance.
+5. If a repository-local rule conflicts with a shared rule, the local repository rule takes precedence.
 
-After you start with `AGENTS.md` and identify the files relevant to the task, when applicable, read the repository in this order:
+When applicable, read the repository in this order:
 
 1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
 2. [docs/architecture.md](docs/architecture.md) for the template architecture placeholder and future design notes.


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary
- replace the unconditional AGENTS.md entrypoint wording with a task-based protocol
- make the repository reading order conditional on relevance to the current task
- remove the redundant "Start with AGENTS.md" step from the local guidance

## Testing
- `make build`
- `make check-all`
- automatic `pre-commit` hooks on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20397](https://softwareone.atlassian.net/browse/MPT-20397)

- Simplified AGENTS.md entrypoint guidance by removing the unconditional instruction to start by reading AGENTS.md itself
- Made repository reading order conditional on task relevance, replacing "After you start with AGENTS.md..." phrasing with "When applicable" lead-in
- Reordered initial protocol steps to prioritize task type identification and selection of relevant local files before repository documentation review

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20397]: https://softwareone.atlassian.net/browse/MPT-20397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ