### PR TITLE
MPT-21040 add agreement UI module and backend plug

### DIFF
--- a/backend/.env.local
+++ b/backend/.env.local
@@ -1,5 +1,5 @@
 # Demo application settings used by the extension and local integrations.
-MPT_API_BASE_URL=http://devmock:8000/extension
+MPT_API_BASE_URL=http://devmock:8000
 MPT_PRODUCTS_IDS=PRD-1111-1111
 # MPT tool settings
 MPT_TOOL_STORAGE_TYPE=local

--- a/backend/swo_playground/app.py
+++ b/backend/swo_playground/app.py
@@ -2,7 +2,9 @@ from mpt_extension_sdk import ExtensionApp
 
 from swo_playground.routers.api.agreements import agreements_router
 from swo_playground.routers.events.order import orders_router
+from swo_playground.routers.plugs import plugs_router
 
 ext_app = ExtensionApp(prefix="/api/v2", version="6.0.0")
 ext_app.include_router(orders_router)
 ext_app.include_router(agreements_router)
+ext_app.include_router(plugs_router)

--- a/backend/swo_playground/routers/plugs.py
+++ b/backend/swo_playground/routers/plugs.py
@@ -1,0 +1,18 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+plugs_router = PlugRouter()
+
+
+@plugs_router.register()
+def agreement_plugs() -> list[Plug]:
+    """Declare agreement UI plugs served from the static asset bridge."""
+    return [
+        Plug(
+            id="agreement-playground",
+            name="Playground",
+            description="Synchronize the current agreement with Marketplace data.",
+            socket="portal.commerce.agreements.agreement",
+            href="/static/agreement/index.js",
+        ),
+    ]

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,15 +1,36 @@
-from mpt_extension_sdk.routing import APIRouteDefinition, EventRouteDefinition
+from mpt_extension_sdk.routing import (
+    APIRouteDefinition,
+    EventRouteDefinition,
+    PlugRouteDefinition,
+)
 
 from swo_playground.app import ext_app
 
 
 def test_app_registers_event_routes():
-    result = ext_app.routes  # act
+    result = ext_app.routes
 
     assert any(isinstance(route, EventRouteDefinition) for route in result)
+    assert any(isinstance(route, PlugRouteDefinition) for route in result)
 
 
 def test_app_registers_sync_route():
-    result = {route.path: route for route in ext_app.routes}  # act
+    result = {route.path: route for route in ext_app.routes}
 
     assert isinstance(result["/api/v2/agreements/{agreement_id}/sync"], APIRouteDefinition)
+
+
+def test_app_generates_agreement_plug_metadata():
+    result = ext_app.to_meta_config()
+
+    assert result.plugs is not None
+    assert len(result.plugs) == 1
+    assert result.plugs[0].model_dump() == {
+        "id": "agreement-playground",
+        "name": "Playground",
+        "description": "Synchronize the current agreement with Marketplace data.",
+        "icon": None,
+        "socket": "portal.commerce.agreements.agreement",
+        "condition": None,
+        "href": "/static/agreement/index.js",
+    }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "watch:types": "tsc -p tsconfig.json --watch",
     "watch:code": "node esbuild.config.js --watch",
     "start": "npm-run-all --parallel watch:types watch:code",
-    "test": "jest --runInBand --passWithNoTests"
+    "test": "jest --runInBand"
   },
   "files": [
     "../static"

--- a/frontend/src/modules/agreement/App.test.tsx
+++ b/frontend/src/modules/agreement/App.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { http } from '@mpt-extension/sdk';
+import { useMPTContext } from '@mpt-extension/sdk-react';
+
+import App from './App';
+
+jest.mock('@mpt-extension/sdk', () => ({
+  http: {
+    post: jest.fn(),
+  },
+}), { virtual: true });
+
+jest.mock('@mpt-extension/sdk-react', () => ({
+  useMPTContext: jest.fn(),
+}), { virtual: true });
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/button', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    Button: ({
+      children,
+      isBusy,
+      isDisabled,
+      onClick,
+    }: {
+      children?: import('react').ReactNode;
+      isBusy?: boolean;
+      isDisabled?: boolean;
+      onClick?: () => void;
+    }) => React.createElement('button', { disabled: isDisabled || isBusy, onClick }, children),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/chip', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    Chip: ({ label }: { label?: string }) => React.createElement('span', null, label),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/divider', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    Divider: () => React.createElement('hr', null),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/notification', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    InlineNotification: ({ children }: { children?: import('react').ReactNode }) =>
+      React.createElement('div', null, children),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/text', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const renderText = ({
+    as = 'span',
+    children,
+  }: {
+    as?: string;
+    children?: import('react').ReactNode;
+  }) => React.createElement(as, null, children);
+
+  return {
+    BoldText: renderText,
+    RegularText: renderText,
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/utils', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    DesignSystemOptionsProvider: ({ children }: { children?: import('react').ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+const mockPost = jest.mocked(http.post);
+const mockUseMPTContext = jest.mocked(useMPTContext);
+
+describe('agreement plug app', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks the sync as successful after a successful request', async () => {
+    mockUseMPTContext.mockReturnValue({ data: { agreement: { id: 'AGR-1234-5678-9012' } } });
+    mockPost.mockResolvedValue({ data: { data: {} } });
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sync now' }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/agreements/AGR-1234-5678-9012/sync');
+    });
+    expect(await screen.findAllByText('Success')).not.toHaveLength(0);
+  });
+
+  it('disables synchronization when the agreement context is missing', () => {
+    mockUseMPTContext.mockReturnValue({});
+
+    render(<App />);
+
+    expect(screen.getByRole('button', { name: 'Sync now' })).toBeDisabled();
+    expect(screen.getByText('Agreement context was not provided by Marketplace.')).toBeInTheDocument();
+  });
+
+  it('renders synchronization errors', async () => {
+    mockUseMPTContext.mockReturnValue({ data: { agreement: { id: 'AGR-1234-5678-9012' } } });
+    mockPost.mockRejectedValue(new Error('Marketplace unavailable'));
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sync now' }));
+
+    expect(await screen.findByText('Marketplace unavailable')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/modules/agreement/App.tsx
+++ b/frontend/src/modules/agreement/App.tsx
@@ -1,0 +1,131 @@
+import { Button } from '@softwareone-platform/sdk-react-ui-v0/button';
+import { Chip } from '@softwareone-platform/sdk-react-ui-v0/chip';
+import { Divider } from '@softwareone-platform/sdk-react-ui-v0/divider';
+import { InlineNotification } from '@softwareone-platform/sdk-react-ui-v0/notification';
+import { BoldText, RegularText } from '@softwareone-platform/sdk-react-ui-v0/text';
+import { DesignSystemOptionsProvider } from '@softwareone-platform/sdk-react-ui-v0/utils';
+
+import { Field } from './components/Field';
+import { useAgreementId } from './hooks/useAgreementId';
+import { Status, useAgreementSync } from './hooks/useAgreementSync';
+
+const STATUS_LABEL: Record<Status, string> = {
+  idle: 'Idle',
+  loading: 'Synchronising',
+  success: 'Success',
+  error: 'Error',
+};
+
+const STATUS_COLOR: Record<Status, 'gray' | 'primary' | 'success' | 'danger'> = {
+  idle: 'gray',
+  loading: 'primary',
+  success: 'success',
+  error: 'danger',
+};
+
+export default function App() {
+  const agreementId = useAgreementId();
+  const { error, lastCompleted, lastStatus, status, syncAgreement } = useAgreementSync(agreementId);
+
+  return (
+    <DesignSystemOptionsProvider
+      value={{
+        dateFormat: 'dd MMM yyyy',
+        inputDateFormat: 'P',
+        languageCode: 'en-GB',
+        timeFormat: 'HH:mm',
+      }}
+    >
+      <div className="playground">
+        <aside className="playground__sidebar" aria-label="Playground sections">
+          <RegularText
+            as="h3"
+            size={1}
+            color="grey-5"
+            className="playground__sidebar-heading"
+          >
+            Manage account
+          </RegularText>
+          <nav>
+            <a
+              href="#sync-account"
+              aria-current="location"
+              className="playground__sidebar-item playground__sidebar-item--active"
+            >
+              <BoldText as="span" size={2}>Sync account</BoldText>
+            </a>
+          </nav>
+        </aside>
+
+        <section className="playground__content" id="sync-account">
+          <header className="playground__content-header">
+            <BoldText as="h2" size={4} className="playground__content-title">
+              Sync account
+            </BoldText>
+            <RegularText as="p" size={2} color="grey-5">
+              The details of this customer&apos;s synchronisation status are below.
+            </RegularText>
+          </header>
+
+          {!agreementId && (
+            <InlineNotification status="warning" isStandalone>
+              Agreement context was not provided by Marketplace.
+            </InlineNotification>
+          )}
+
+          <InlineNotification status="info" isStandalone>
+            If agreement synchronisation fails, please create a Helpdesk case.
+          </InlineNotification>
+
+          <section className="playground__section">
+            <BoldText as="h3" size={3} className="playground__section-title">
+              Synchronisation status
+            </BoldText>
+            <dl className="playground__fields">
+              <Field label="Current status">
+                <Chip color={STATUS_COLOR[status]} label={STATUS_LABEL[status]} />
+              </Field>
+              <Field label="Last sync status">
+                {lastStatus ? STATUS_LABEL[lastStatus] : '—'}
+              </Field>
+              <Field label="Last sync completed">
+                {lastCompleted ?? '—'}
+              </Field>
+              <Field label="Next sync available">Now</Field>
+            </dl>
+          </section>
+
+          <Divider />
+
+          <section className="playground__section">
+            <BoldText as="h3" size={3} className="playground__section-title">
+              Synchronise now
+            </BoldText>
+            <RegularText as="p" size={2} color="grey-5">
+              To request a sync, click the &ldquo;Sync now&rdquo; button below.
+            </RegularText>
+            <Button
+              isBusy={status === 'loading'}
+              isDisabled={!agreementId}
+              onClick={syncAgreement}
+              type="primary"
+            >
+              Sync now
+            </Button>
+          </section>
+
+          {status === 'error' && (
+            <InlineNotification status="error" isStandalone>
+              {error}
+            </InlineNotification>
+          )}
+          {status === 'success' && (
+            <InlineNotification status="warning" isStandalone>
+              This is a demo playground. The agreement was not modified.
+            </InlineNotification>
+          )}
+        </section>
+      </div>
+    </DesignSystemOptionsProvider>
+  );
+}

--- a/frontend/src/modules/agreement/components/Field.tsx
+++ b/frontend/src/modules/agreement/components/Field.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+import { RegularText } from '@softwareone-platform/sdk-react-ui-v0/text';
+
+interface FieldProps {
+  children: ReactNode;
+  label: string;
+}
+
+export function Field({ label, children }: FieldProps) {
+  return (
+    <div className="playground__field">
+      <RegularText as="dt" size={2} color="grey-5" className="playground__field-label">
+        {label}
+      </RegularText>
+      <dd className="playground__field-value">
+        {typeof children === 'string' ? (
+          <RegularText as="span" size={2}>
+            {children}
+          </RegularText>
+        ) : (
+          children
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/frontend/src/modules/agreement/hooks/useAgreementId.test.ts
+++ b/frontend/src/modules/agreement/hooks/useAgreementId.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+
+import { useMPTContext } from '@mpt-extension/sdk-react';
+
+import { useAgreementId } from './useAgreementId';
+
+jest.mock('@mpt-extension/sdk-react', () => ({
+  useMPTContext: jest.fn(),
+}), { virtual: true });
+
+const mockUseMPTContext = jest.mocked(useMPTContext);
+
+describe('useAgreementId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the agreement id from the Marketplace context', () => {
+    mockUseMPTContext.mockReturnValue({
+      data: {
+        agreement: {
+          id: 'AGR-1234-5678-9012',
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useAgreementId());
+
+    expect(result.current).toBe('AGR-1234-5678-9012');
+  });
+
+  it('returns an empty id when the Marketplace context has no agreement', () => {
+    mockUseMPTContext.mockReturnValue({});
+
+    const { result } = renderHook(() => useAgreementId());
+
+    expect(result.current).toBe('');
+  });
+});

--- a/frontend/src/modules/agreement/hooks/useAgreementId.ts
+++ b/frontend/src/modules/agreement/hooks/useAgreementId.ts
@@ -1,0 +1,9 @@
+import { useMPTContext } from '@mpt-extension/sdk-react';
+
+import { AgreementContext, resolveAgreementId } from '../model';
+
+export function useAgreementId(): string {
+  const context = useMPTContext() as AgreementContext;
+
+  return resolveAgreementId(context);
+}

--- a/frontend/src/modules/agreement/hooks/useAgreementSync.test.ts
+++ b/frontend/src/modules/agreement/hooks/useAgreementSync.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { http } from '@mpt-extension/sdk';
+
+import { useAgreementSync } from './useAgreementSync';
+
+jest.mock('@mpt-extension/sdk', () => ({
+  http: {
+    post: jest.fn(),
+  },
+}), { virtual: true });
+
+const mockPost = jest.mocked(http.post);
+
+describe('useAgreementSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('posts the encoded agreement id and records successful completion', async () => {
+    mockPost.mockResolvedValue({ data: { data: {} } });
+
+    const { result } = renderHook(() => useAgreementSync('AGR-1234-5678-9012'));
+
+    await act(async () => {
+      await result.current.syncAgreement();
+    });
+
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/agreements/AGR-1234-5678-9012/sync');
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.lastStatus).toBe('success');
+    expect(result.current.lastCompleted).toEqual(expect.any(String));
+    expect(result.current.error).toBe('');
+  });
+
+  it('does not post when agreement id is missing', async () => {
+    const { result } = renderHook(() => useAgreementSync(''));
+
+    await act(async () => {
+      await result.current.syncAgreement();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('records sync failures', async () => {
+    mockPost.mockRejectedValue(new Error('Marketplace unavailable'));
+
+    const { result } = renderHook(() => useAgreementSync('AGR-1234-5678-9012'));
+
+    await act(async () => {
+      await result.current.syncAgreement();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.lastStatus).toBe('error');
+    expect(result.current.lastCompleted).toEqual(expect.any(String));
+    expect(result.current.error).toBe('Marketplace unavailable');
+  });
+});

--- a/frontend/src/modules/agreement/hooks/useAgreementSync.ts
+++ b/frontend/src/modules/agreement/hooks/useAgreementSync.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react';
+
+import { http } from '@mpt-extension/sdk';
+
+export type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface SyncState {
+  error: string;
+  lastCompleted: string | null;
+  lastStatus: Status | null;
+  status: Status;
+}
+
+const INITIAL_SYNC_STATE: SyncState = {
+  error: '',
+  lastCompleted: null,
+  lastStatus: null,
+  status: 'idle',
+};
+
+export function useAgreementSync(agreementId: string) {
+  const [state, setState] = useState<SyncState>(INITIAL_SYNC_STATE);
+
+  const syncAgreement = useCallback(async () => {
+    if (!agreementId) {
+      return;
+    }
+
+    setState((current) => ({ ...current, error: '', status: 'loading' }));
+
+    try {
+      const encodedAgreementId = encodeURIComponent(agreementId);
+      await http.post(`/api/v2/agreements/${encodedAgreementId}/sync`);
+      setState({
+        error: '',
+        lastCompleted: new Date().toLocaleString(),
+        lastStatus: 'success',
+        status: 'success',
+      });
+    } catch (syncError) {
+      const error = syncError instanceof Error ? syncError.message : 'Agreement sync failed.';
+      setState({
+        error,
+        lastCompleted: new Date().toLocaleString(),
+        lastStatus: 'error',
+        status: 'error',
+      });
+    }
+  }, [agreementId]);
+
+  return { ...state, syncAgreement };
+}

--- a/frontend/src/modules/agreement/index.tsx
+++ b/frontend/src/modules/agreement/index.tsx
@@ -1,0 +1,11 @@
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<App />);
+});

--- a/frontend/src/modules/agreement/model.test.ts
+++ b/frontend/src/modules/agreement/model.test.ts
@@ -1,0 +1,33 @@
+import { resolveAgreementId } from './model';
+
+describe('agreement model helpers', () => {
+  it('resolves agreement id from the Marketplace context agreement', () => {
+    const result = resolveAgreementId({
+      data: {
+        agreement: {
+          id: 'AGR-1234-5678-9012',
+        },
+      },
+    });
+
+    expect(result).toBe('AGR-1234-5678-9012');
+  });
+
+  it('trims agreement id from the Marketplace context agreement', () => {
+    const result = resolveAgreementId({
+      data: {
+        agreement: {
+          id: ' AGR-9876-5432-1098 ',
+        },
+      },
+    });
+
+    expect(result).toBe('AGR-9876-5432-1098');
+  });
+
+  it('returns an empty agreement id when the context agreement is missing', () => {
+    const result = resolveAgreementId({});
+
+    expect(result).toBe('');
+  });
+});

--- a/frontend/src/modules/agreement/model.ts
+++ b/frontend/src/modules/agreement/model.ts
@@ -1,0 +1,14 @@
+export interface Reference {
+  id?: string;
+  name?: string;
+}
+
+export interface AgreementContext {
+  data?: {
+    agreement?: Reference;
+  };
+}
+
+export function resolveAgreementId(context?: AgreementContext): string {
+  return context?.data?.agreement?.id?.trim() ?? '';
+}

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -1,0 +1,77 @@
+@use '@softwareone-platform/sdk-react-ui-v0/design-tokens' as *;
+@use '@softwareone-platform/sdk-react-ui-v0/design-tokens/style';
+
+.playground {
+  display: grid;
+  gap: var(--spacing-5);
+  grid-template-columns: minmax(180px, 220px) 1fr;
+  padding: var(--spacing-4) 0;
+}
+
+.playground__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.playground__sidebar-heading {
+  margin: 0;
+  text-transform: none;
+}
+
+.playground__sidebar-item {
+  border-left: 2px solid transparent;
+  color: inherit;
+  display: block;
+  padding: var(--spacing-2) var(--spacing-3);
+  text-decoration: none;
+}
+
+.playground__sidebar-item--active {
+  border-left-color: var(--blue-6);
+  color: var(--blue-7);
+}
+
+.playground__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  min-width: 0;
+}
+
+.playground__content-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.playground__content-title {
+  margin: 0;
+}
+
+.playground__section {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.playground__section-title {
+  margin: 0;
+}
+
+.playground__fields {
+  display: grid;
+  gap: var(--spacing-2) var(--spacing-4);
+  grid-template-columns: minmax(160px, max-content) 1fr;
+  margin: 0;
+}
+
+.playground__field {
+  display: contents;
+}
+
+.playground__field-label,
+.playground__field-value {
+  margin: 0;
+}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Final part of the MPT-21040 split of #59 (after the SDK 6.3.1 update and the frontend scaffolding #62, both merged). Wires the agreement playground end to end.

## What changed

### Backend
- Add `routers/plugs.py`: a `PlugRouter` declaring the `agreement-playground` plug bound to the `portal.commerce.agreements.agreement` socket and served from `/static/agreement/index.js`.
- Register `plugs_router` in the extension app (`app.py`).
- Extend app tests to assert the plug route and its generated meta config.

### Frontend
- Add the agreement module under `frontend/src/modules/agreement/`: `App`, `Field` component, `model`, and the `useAgreementId` / `useAgreementSync` hooks, with their tests.
- Add the playground styles (`frontend/src/style.scss`), imported by the module entrypoint.
- Remove the `modules/.gitkeep` placeholder and run jest without `--passWithNoTests` now that real tests exist.

### Tooling
- Declare `swo_playground` as a first-party isort package so ruff produces the same import grouping when run from the repo root (pre-commit) and from `backend/` (`make check`), unblocking the pre-commit ruff hook.
- Point `MPT_API_BASE_URL` in `.env.local` at the devmock root.

## Testing
- `make check-all scope=all` green: backend lint (ruff/flake8/mypy), 7 backend tests, 12 frontend tests, and `mpt-ext meta generate` + `validate`.

Closes MPT-21040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21040](https://softwareone.atlassian.net/browse/MPT-21040)

- Backend
  - Add routers/plugs.py with PlugRouter registering an "agreement-playground" plug bound to the portal.commerce.agreements.agreement socket and served from /static/agreement/index.js
  - Register plugs_router in swo_playground/app.py
  - Extend backend tests (test_app.py) to assert plug route presence and validate generated plug metadata
  - Update backend/.env.local MPT_API_BASE_URL -> http://devmock:8000

- Frontend
  - Add agreement playground module at frontend/src/modules/agreement/:
    - App component (agreement sync UI)
    - Field component (label/value)
    - model.ts (AgreementContext, Reference, resolveAgreementId)
    - useAgreementId and useAgreementSync hooks (with tests)
    - Module entrypoint index.tsx importing style.scss
  - Add playground styles at frontend/src/style.scss
  - Remove modules/.gitkeep
  - Update frontend package.json test script to remove --passWithNoTests
  - Add comprehensive Jest tests for components and hooks

- Tooling / Config
  - Declare swo_playground as a first-party isort package for consistent import grouping

- Testing
  - make check-all (scope=all) green: backend lint (ruff/flake8/mypy), backend tests (7), frontend tests (12), and mpt-ext meta generate + validate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-extension-playground/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21040]: https://softwareone.atlassian.net/browse/MPT-21040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ