### PR TITLE
MPT-21551: add data and schema migrations

### DIFF
--- a/backend/migrations/20260527134121_fake_data_migration.py
+++ b/backend/migrations/20260527134121_fake_data_migration.py
@@ -1,0 +1,11 @@
+from typing import override
+
+from mpt_tool.migration import DataBaseMigration
+
+
+class Migration(DataBaseMigration):
+    """Fake data migration."""
+
+    @override
+    def run(self) -> None:
+        self.log.info("Fake data migration")

--- a/backend/migrations/20260527134133_fake_schema_migration.py
+++ b/backend/migrations/20260527134133_fake_schema_migration.py
@@ -1,0 +1,11 @@
+from typing import override
+
+from mpt_tool.migration import SchemaBaseMigration
+
+
+class Migration(SchemaBaseMigration):
+    """Fake schema migration."""
+
+    @override
+    def run(self) -> None:
+        self.log.info("Fake schema migration")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,7 +77,9 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202"
+  # The leading `*` makes this match both CI (`migrations/...`) and pre-commit (`backend/migrations/...`) paths.
+  "*migrations/**:WPS102",
+  "*tests/**:WPS202",
 ]
 
 [tool.ruff]
@@ -170,6 +172,7 @@ convention = "google"
 ignore-decorators = ["property"]
 
 [tool.ruff.lint.isort]
+known-first-party = ["swo_playground"]
 known-third-party = ["mpt_extension_sdk"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Add fake data and schema migrations to demostrate the migration flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21551](https://softwareone.atlassian.net/browse/MPT-21551)

- Add backend/migrations/20260527134121_fake_data_migration.py: data migration example that logs "Fake data migration"
- Add backend/migrations/20260527134133_fake_schema_migration.py: schema migration example that logs "Fake schema migration"
- Update backend/pyproject.toml: add flake8 per-file-ignore for migrations ("*migrations/**:WPS102") and set ruff.isort known-first-party to ["swo_playground"]

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-extension-playground/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21551]: https://softwareone.atlassian.net/browse/MPT-21551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ