### PR TITLE
MPT-21040 fix esbuild: discover entrypoints before wiping static output

### DIFF
--- a/frontend/esbuild.config.js
+++ b/frontend/esbuild.config.js
@@ -10,21 +10,22 @@ const env = JSON.stringify(process.env.NODE_ENV ?? 'production');
 const outdir = path.resolve(__dirname, '../static');
 const modulesdir = path.resolve(__dirname, './src/modules');
 
+const entryPoints = readdirSync(modulesdir, { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => path.join(modulesdir, dirent.name, 'index.tsx'))
+  .filter((filePath) => existsSync(filePath))
+  .sort();
+
+if (entryPoints.length === 0) {
+  console.log('No frontend module entrypoints found.');
+  process.exit(0);
+}
+
 mkdirSync(outdir, { recursive: true });
 if (!watch) {
   for (const entry of readdirSync(outdir)) {
     rmSync(path.join(outdir, entry), { recursive: true, force: true });
   }
-}
-
-const entryPoints = readdirSync(modulesdir, { withFileTypes: true })
-  .filter((dirent) => dirent.isDirectory())
-  .map((dirent) => path.join(modulesdir, dirent.name, 'index.tsx'))
-  .filter((filePath) => existsSync(filePath));
-
-if (entryPoints.length === 0) {
-  console.log('No frontend module entrypoints found.');
-  process.exit(0);
 }
 
 const ctx = await context({


### PR DESCRIPTION
## Summary
Fixes two issues in `frontend/esbuild.config.js` raised in review of #62 (MPT-21040 frontend scaffolding).

## What changed
- **Reordered the build steps:** entrypoint discovery and the empty-entrypoints guard now run *before* the `mkdir`/`rm` block that wipes `../static`. Previously `../static` was wiped first; if discovery came up empty (renamed/moved modules, or running from the wrong cwd), the output was already deleted and the process exited `0` — reporting a successful build that produced no assets. This is risky in the release pipeline, where it would silently ship an empty `static/`.
- **Added `.sort()`** to the discovered entrypoints so the build is deterministic across platforms (`readdirSync` order is not guaranteed between macOS/Linux/filesystems).

## Why
Both come from review feedback by @robcsegal on PR #62. The reorder prevents data loss + false-success builds; the sort makes builds reproducible.

## Reviewer notes
- No behavior change when entrypoints exist — only ordering of the wipe relative to discovery, plus deterministic ordering.
- Logic-only change; no new deps.

Relates to MPT-21040.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21040](https://softwareone.atlassian.net/browse/MPT-21040)

- Run entrypoint discovery (and the empty-entrypoints guard) before creating/cleaning the ../static output directory to avoid wiping static assets prematurely and prevent false-success builds when no entrypoints are found
- Sort discovered entrypoints (.sort()) for deterministic ordering across platforms/filesystems
- Non-watch builds exit non-zero when no entrypoints are discovered; watch mode remains exit 0 so the watcher stays alive
- Logic-only change; no behavior change when entrypoints exist and no new dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-extension-playground/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21040]: https://softwareone.atlassian.net/browse/MPT-21040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ