### PR TITLE
MPT-21040 update order event router from status_change to status_changed

### DIFF
--- a/backend/swo_playground/routers/events/order.py
+++ b/backend/swo_playground/routers/events/order.py
@@ -14,7 +14,7 @@ orders_router = EventRouter(prefix="/events/v2/orders")
 @orders_router.task(
     path="/purchase",
     name="orders-purchase",
-    event="platform.commerce.order.status_change",
+    event="platform.commerce.order.status_changed",
     condition="eq(product.id,PRD-5516-5707)",
 )
 async def process_order_purchase(event: Event, context: OrderContext) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21040](https://softwareone.atlassian.net/browse/MPT-21040)

- Updated the order event router to listen for `platform.commerce.order.status_changed` event instead of `platform.commerce.order.status_change`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-extension-playground/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21040]: https://softwareone.atlassian.net/browse/MPT-21040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ