### PR TITLE
MPT-21850 track shared CodeRabbit config from main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/7b6256cafd72aca2026726561d54871f973c159f/coderabbit-shared.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Updated the CodeRabbit remote configuration URL to use the main branch version of mpt-extension-skills/coderabbit-shared.yaml.
- Removed the pinned commit SHA from the remote config URL so CodeRabbit can pick up the latest shared configuration from main.

## Testing
- ruby -e YAML.load_file(".coderabbit.yaml")
- make check-all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

- Updated `.coderabbit.yaml` to reference the shared CodeRabbit configuration from the `main` branch instead of a pinned commit SHA
- Changed `remote_config.url` from a specific commit hash URL to `https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml` to ensure the latest shared configuration is always used

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21850]: https://softwareone.atlassian.net/browse/MPT-21850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ