### PR TITLE
MPT-21678 improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 `swo-extension-playground` is a minimal SoftwareOne Marketplace extension built on top of `mpt-extension-sdk` and `mpt-tool`.
 
-It is primarily a playground repository: it shows the baseline extension shape, a simple validation API endpoint, an event listener, a small fulfillment pipeline, and the development workflow used by extension repositories in this ecosystem.
+It is primarily a playground repository: it shows the baseline extension shape, agreement API endpoints, order and agreement event listeners, small fulfillment pipelines, Marketplace Portal plugs, and the development workflow used by extension repositories in this ecosystem.
 
 ## Repository Layout
 
 - `backend/swo_playground/` contains the extension package.
 - `backend/tests/` contains the pytest suite.
+- `frontend/` contains the React plug source code.
+- `static/` contains generated plug assets served by the extension.
 - `make/*.mk` contains the repository make targets.
-- `compose.yaml` defines the local Docker-based development environment.
+- `compose.yaml` defines the Docker-based development environment.
+- `compose.local.yaml` adds local mock services for `mpt-ext run --local`.
 
 ## Quick Start
 
@@ -23,10 +26,12 @@ Recommended setup:
 ```bash
 make build
 make test
-make run
+make run-local
 ```
 
-The application runs on `http://localhost:8080`.
+Local mock mode exposes the application on `http://localhost:8080`.
+
+Most make targets accept `scope=backend`, `scope=frontend`, or `scope=all`. The default scope is `all`.
 
 ## Common Commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,22 +2,42 @@
 
 Keep this document focused on actual architecture decisions for the repository.
 
-If the repository does not yet have stable architectural decisions, keep this file short and avoid speculative descriptions.
+This repository is a small Marketplace extension playground. It is intentionally minimal, but it now has stable backend and frontend examples that should stay documented here.
 
-## What To Document Here
+## Runtime Components
 
-When architecture details become relevant, document:
+- `backend/swo_playground/app.py` creates the `ExtensionApp` and registers all routers.
+- `backend/swo_playground/routers/api/` exposes extension API endpoints.
+- `backend/swo_playground/routers/events/` declares Marketplace event handlers.
+- `backend/swo_playground/flows/pipelines/` contains simple order and agreement pipelines.
+- `backend/swo_playground/flows/steps/` contains reusable pipeline steps.
+- `backend/swo_playground/routers/plugs/` declares Marketplace Portal plug metadata.
+- `frontend/src/modules/` contains the React plug entry points.
+- `static/` contains generated frontend bundles served by the backend.
 
-- the main runtime components
-- repository boundaries and responsibility split
-- extension entry points
-- data flow between API handlers, event listeners, pipelines, and external services
-- any persistence model and migration boundaries
-- important design decisions or tradeoffs
+## Entry Points
+
+The extension currently registers:
+
+- agreement API routes under `/api/v2/agreements`
+- order event route `/events/v2/orders/purchase`
+- agreement event route `/events/v2/agreements/complete`
+- agreement-related Marketplace Portal plugs that load bundles from `/static/`
+
+## Data Flow
+
+Agreement API handlers read Marketplace agreement data through the SDK API service and return SDK `APIResponse` objects.
+
+Event handlers receive Marketplace event payloads, log the event context, and execute a small pipeline. The pipelines are deliberately simple examples and should remain focused on extension-layer behavior rather than SDK internals.
+
+Portal plugs are declared by backend metadata. The frontend build writes JavaScript bundles into `static/`; those bundles are referenced by plug `href` values and mounted into the backend container.
+
+## Persistence And Migrations
+
+Migration examples live in `backend/migrations/` and are managed by `mpt-tool`; see [docs/migrations.md](migrations.md).
 
 ## Guidance
 
-- Keep this file minimal until there is real architecture to describe.
 - Avoid fictional or speculative architecture.
 - Put workflow details in the other topic-specific documents under `docs/`.
 - Update this file when the repository gains stable components or non-trivial design rules.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ Shared operational knowledge also lives there:
 The default development environment is Docker-based.
 
 - Use `make build` to build the image and sync dependencies with `uv`.
-- Use `make bash` or `make shell` when you need an interactive container session.
+- Use `make bash` when you need an interactive backend container session.
 
 If the repository supports a local-only workflow outside Docker, document it explicitly in [docs/local-development.md](local-development.md). Otherwise, treat Docker as the default path.
 
@@ -48,7 +48,7 @@ make check
 make test
 ```
 
-Use `make check-all` when the repository exposes it and you want the combined validation workflow.
+Use `make check-all` for the combined validation workflow. Most targets accept `scope=backend`, `scope=frontend`, or `scope=all`; the default is `all`.
 
 See [docs/testing.md](testing.md) for repository-specific testing expectations.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,13 @@ It is the source of truth for environment parameters referenced by local develop
 
 ## Configuration Source
 
-The repository runtime expects environment variables, typically provided through `.env` for local Docker Compose usage.
+The repository runtime expects environment variables, typically provided through files under `backend/` for local Docker Compose usage.
+
+Docker Compose reads:
+
+- `backend/.env` for the default platform integration workflow
+- `backend/.env.local` for local mock mode
+- `backend/.env.sample` as sample values for local checks and metadata validation. Inside the backend container, this file is available as `.env.sample`.
 
 Local setup instructions live in [docs/local-development.md](local-development.md).
 
@@ -14,13 +20,8 @@ Local setup instructions live in [docs/local-development.md](local-development.m
 
 | Environment Variable | Default | Example | Description |
 | --- | --- | --- | --- |
-| `EXT_WEBHOOKS_SECRETS` | - | `{"PRD-1111-1111": "123qweasd3432234"}` | Webhook secret keyed by Marketplace product id |
 | `MPT_API_BASE_URL` | `http://localhost:8000` | `https://api.platform.softwareone.com` | SoftwareOne Marketplace API URL |
-| `MPT_API_TOKEN` | - | `eyJhbGciOiJSUzI1N...` | SoftwareOne Marketplace API token |
-| `MPT_INITIALIZER` | - | `<package>.initializer.initialize` | Optional initializer function |
-| `MPT_KEY_VAULT_NAME` | `mpt-key-vault` | `<key-vault-name>` | Key Vault name |
 | `MPT_PRODUCTS_IDS` | `PRD-1111-1111` | `PRD-1234-1234,PRD-4321-4321` | Comma-separated list of Marketplace product ids |
-| `MPT_PORTAL_BASE_URL` | `http://localhost:8000` | `https://portal.softwareone.com` | SoftwareOne Marketplace Portal URL |
 | `MPT_TOOL_STORAGE_TYPE` | `local` | `airtable` | Storage type for MPT tools |
 | `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXXXXXXXX` | Airtable API key when Airtable storage is enabled |
 | `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID` | - | `appXXXXXXXXXXXXXX` | Airtable base id when Airtable storage is enabled |
@@ -38,16 +39,11 @@ Local setup instructions live in [docs/local-development.md](local-development.m
 
 ## Local Example
 
-Example `.env` snippet:
+Example `backend/.env` snippet for platform integration:
 
 ```env
-EXT_WEBHOOKS_SECRETS={"PRD-1111-1111": "<webhook-secret-for-product>", "PRD-2222-2222": "<webhook-secret-for-product>"}
 MPT_API_BASE_URL=https://api.s1.show
-MPT_API_TOKEN=c0fdafd7-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-MPT_INITIALIZER="<package>.initializer.initialize"
-MPT_KEY_VAULT_NAME=""
 MPT_ORDERS_API_POLLING_INTERVAL_SECS=120
-MPT_PORTAL_BASE_URL=https://portal.s1.show
 MPT_PRODUCTS_IDS=PRD-1111-1111,PRD-2222-2222
 MPT_TOOL_STORAGE_TYPE=local
 MPT_TOOL_STORAGE_AIRTABLE_API_KEY=<airtable-api-key>
@@ -55,10 +51,18 @@ MPT_TOOL_STORAGE_AIRTABLE_BASE_ID=<airtable-base-id>
 MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME=<airtable-table-name>
 ```
 
-`MPT_PRODUCTS_IDS` is a comma-separated list of Marketplace product identifiers.
+Example `backend/.env.local` snippet for devmock local mode:
 
-For each product id in `MPT_PRODUCTS_IDS`, define the corresponding secret in `EXT_WEBHOOKS_SECRETS` using the product id as the key.
+```env
+MPT_API_BASE_URL=http://devmock:8000
+MPT_PRODUCTS_IDS=PRD-1111-1111
+MPT_TOOL_STORAGE_TYPE=local
+```
+
+`MPT_PRODUCTS_IDS` is a comma-separated list of Marketplace product identifiers.
 
 The `MPT_TOOL_STORAGE_*` variables mirror the storage configuration documented in `mpt-tool`. When `MPT_TOOL_STORAGE_TYPE=local`, the Airtable variables may remain unset locally. When `MPT_TOOL_STORAGE_TYPE=airtable`, set `MPT_TOOL_STORAGE_AIRTABLE_API_KEY`, `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID`, and `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` together.
 
-Adjust examples in this file to match the actual package names, service names, endpoints, and integrations used by the target repository.
+## Static Assets
+
+Frontend plug bundles are generated into `static/` and mounted into the backend container at `/extension/static`. Plug metadata references these bundles with `/static/...` hrefs.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -18,6 +18,8 @@ This file documents repository-specific documentation rules only.
 
 - [`README.md`](../README.md): human entry point, overview, quick start, and documentation map
 - [`AGENTS.md`](../AGENTS.md): AI entry point and reading order
+- [`architecture.md`](architecture.md): stable runtime components, entry points, and data flow
+- [`local-development.md`](local-development.md): Docker, local mock mode, frontend watch, and environment file usage
 - [`deployment.md`](deployment.md): runtime configuration and deployment model
 - [`contributing.md`](contributing.md): repository-specific development workflow
 - [`testing.md`](testing.md): testing strategy and command mapping

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -15,34 +15,74 @@ Build the development image and install dependencies:
 make build
 ```
 
+`make build` uses `scope=all` by default. To work on one side only:
+
+```bash
+make build scope=backend
+make build scope=frontend
+```
+
 ## Running the Service
 
-Start the service with Docker Compose:
+Start the service in platform integration mode:
 
 ```bash
 make run
 ```
 
-The service is exposed on `http://localhost:8080`.
+`make run` starts backend, frontend, and Jaeger when `scope=all`. Use scoped startup when needed:
+
+```bash
+make run scope=backend
+make run scope=frontend
+```
+
+The frontend container watches `frontend/` and writes generated plug assets into `static/`.
+
+## Local Mock Mode
+
+For local development without a real Marketplace API, use:
+
+```bash
+make run-local
+```
+
+This runs the backend with `mpt-ext run --local` and starts the WireMock devmock service from `compose.local.yaml`. The extension service is exposed on `http://localhost:8080`; the devmock service listens on `http://localhost:8000` and uses mappings under `peripherals/devmock/`.
+
+Local mock mode requires `backend/.env.local`. The sample values in `backend/.env.sample` show the expected local devmock shape.
 
 Useful helper commands:
 
 ```bash
 make bash
-make shell
 make down
+make logs
 ```
 
 ## Environment Parameters
 
-Local startup requires an `.env` file consumed by Docker Compose.
+Local startup reads environment files from the backend directory:
+
+- `backend/.env` is optional for the default Compose workflow.
+- `backend/.env.local` is required by `make run-local`.
+- `backend/.env.sample` contains sample values used by local checks and metadata validation.
 
 The parameter reference lives in [docs/deployment.md](deployment.md). Use that document for:
 
 - required and optional environment variables
 - example values
-- runtime-specific notes for Marketplace integration, webhook secrets, Airtable, and AppInsights
+- runtime-specific notes for Marketplace integration and AppInsights
 
 Do not duplicate the parameter reference in this file.
 
-Adjust startup commands, URLs, and helper commands in this file if the target repository differs from the defaults documented here.
+## Frontend Development
+
+Frontend source lives under `frontend/src/`. The build creates static plug bundles under `static/`, which are served by the backend and referenced by the plug metadata.
+
+Use the repository make targets instead of running npm directly unless debugging a frontend-only issue:
+
+```bash
+make check scope=frontend
+make test scope=frontend
+make format scope=frontend
+```

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,24 +1,32 @@
 # Migrations
 
-Use this document only for migration details that are specific to the repository.
-
 Shared migration knowledge lives in:
 
 - [knowledge/migrations.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/migrations.md)
 - [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
 
-If the repository does not yet have repository-specific migration rules, keep this file short and rely on the shared migration knowledge above.
+This file documents repository-specific migration behavior only.
 
-## What To Add Here
+## Migration Files
 
-Add repository-specific migration details only when they exist, for example:
+Repository migration scripts live in [`backend/migrations/`](../backend/migrations/).
 
-- where migration files live
-- which migration commands are actually used in this repository
-- required execution order or rollout rules
-- operational constraints or safety checks
-- differences from the shared migration knowledge
+This repository uses the standard migration workflow and standard make-based command wiring used across related repositories. Use the shared migration knowledge above as the primary reference.
 
-## Documentation Rule
+## Repository-Specific Constraint
 
-When repository-specific migration behavior is introduced or changed, update this document in the same change.
+The current migrations are fake/example migrations used to demonstrate the repository shape:
+
+- `20260527134121_fake_data_migration.py`
+- `20260527134133_fake_schema_migration.py`
+
+Replace or remove these examples when the repository gains real data or schema migrations.
+
+## When To Update This Document
+
+Update this file when the repository changes:
+
+- migration file locations
+- migration command entry points
+- required execution order
+- rollout or safety constraints specific to this repository

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,7 +11,14 @@ This file documents only repository-specific testing behavior.
 
 ## Test Scope
 
-The current test scope is limited to verifying that the app starts with no registered routes.
+The current test scope covers:
+
+- backend app route registration for API, event, and plug routes
+- agreement API handlers
+- order and agreement event handlers
+- order and agreement pipeline execution
+- pipeline step logging behavior
+- frontend plug components, hooks, and shared model helpers
 
 ## Commands
 
@@ -25,9 +32,13 @@ make check-all
 
 Repository command mapping:
 
-- `make test` runs `pytest`
-- `make check` runs `ruff format --check`, `ruff check`, `flake8`, `mypy`, and `uv lock --check`
-- `make check-all` runs both checks and tests
+- `make test` runs backend `pytest` and frontend `jest`
+- `make test scope=backend` runs backend `pytest`
+- `make test scope=frontend` runs frontend `npm test`
+- `make check` runs backend formatting/lint/type/lock checks and frontend TypeScript/ESLint checks
+- `make check scope=backend` runs `ruff format --check`, `ruff check`, `flake8`, `mypy`, and `uv lock --check`
+- `make check scope=frontend` runs `tsc --noEmit` and `eslint`
+- `make check-all` runs checks, tests, frontend build, and metadata generation/validation for `scope=all`
 
 The CI workflow in [`.github/workflows/pr-build-merge.yml`](../.github/workflows/pr-build-merge.yml) uses the same `make build` and `make check-all` flow.
 
@@ -44,9 +55,11 @@ Repository-specific test settings come from [`backend/pyproject.toml`](../backen
 
 Repository-specific guidance:
 
-- Use fixtures from [`tests/conftest.py`](../tests/conftest.py) where possible.
+- Use fixtures from [`backend/tests/conftest.py`](../backend/tests/conftest.py) where possible.
 - Mock external Marketplace SDK calls rather than calling real services.
 - Keep tests focused on the behavior of the extension layer, not on internals of `mpt-extension-sdk` itself.
+- Keep frontend tests close to the component, hook, or model module they cover.
+- Use generated devmock payloads only as stable examples; do not depend on live Marketplace services.
 - Follow the shared unit-test standard for AAA structure, parametrization, mocking rules, deterministic behavior, and coverage expectations.
 
 ## When Tests Are Required
@@ -56,6 +69,8 @@ Add or update tests when a change modifies:
 - API request handling
 - event processing
 - pipeline step behavior
+- plug registration or static asset references
+- frontend plug behavior
 - command output
 - dependency wiring in the extension app
 

--- a/make/common.mk
+++ b/make/common.mk
@@ -1,4 +1,5 @@
 DC ?= docker compose -f compose.yaml
+DC_LOCAL ?= docker compose -f compose.yaml -f compose.local.yaml
 RUN = $(DC) run --rm backend
 RUN_IT = $(DC) run --rm -it backend
 RUN_FRONTEND = $(DC) run --rm frontend
@@ -72,13 +73,13 @@ run:  ## Run service in platform integration mode
 
 run-local:  ## Run backend in --local mode with Jaeger and frontend watch static asset generation
 	@if [ "$(scope)" = "backend" ]; then \
-		$(DC) -f compose.local.yaml up backend; \
+		$(DC_LOCAL) up backend; \
 	fi
 	@if [ "$(scope)" = "frontend" ]; then \
-		$(DC) -f compose.local.yaml up frontend; \
+		$(DC_LOCAL) up frontend; \
 	fi
 	@if [ "$(scope)" = "all" ]; then \
-		$(DC) -f compose.local.yaml up -d; \
+		$(DC_LOCAL) up -d; \
 	fi
 
 test:  ## Run tests. Optional: scope=backend|frontend|all


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

- Updated repository documentation to match the current backend, frontend, local mock, testing, deployment, and migration behavior.
- Documented frontend/static plug assets and make target scopes.
- Clarified local mock startup with devmock and corrected environment-file references.
- Fixed make run-local to apply compose.local.yaml together with compose.yaml.

## Testing
- make build attempted; backend image and frontend build completed, but Jaeger startup was blocked by port 4318 already used by another local project.
- docker compose -f compose.yaml run --rm --no-deps backend uv sync
- docker compose -f compose.yaml run --rm --no-deps backend bash -c "uv run ruff format --check . && uv run ruff check . && uv run flake8 . && uv run mypy . && uv lock --check"
- docker compose -f compose.yaml run --rm --no-deps backend pytest
- docker compose -f compose.yaml run --rm frontend bash -c "npm ci && npm run check && npm test && npm run build"

- docker compose -f compose.yaml run --rm --no-deps backend bash -c "mpt-ext meta generate && mpt-ext meta validate"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21678](https://softwareone.atlassian.net/browse/MPT-21678)

- Update README: expanded project overview (extension playground, agreement API, event listeners, fulfillment pipelines, Marketplace Portal plugs), clarified layout (static/, make/*.mk, compose.local.yaml) and Quick Start (make run-local, scope=backend|frontend|all)
- Add docs/architecture.md: concrete runtime architecture, entry points, data flow, and migrations boundary
- Update docs/contributing.md: require make bash for interactive backend sessions; document make check-all scope options
- Update docs/deployment.md: backend/.env* usage (backend/.env, backend/.env.local, backend/.env.sample), reduced core env var table, and new Static Assets section documenting static/ → /extension/static mount
- Add docs/local-development.md: Docker/make-based workflow, scoped build/run targets, make run-local with mpt-ext run --local + compose.local.yaml devmock, local URLs/ports, frontend watch → static/, and make logs helper
- Rework docs/migrations.md: repository-specific migration behavior, pointer to backend/migrations/, example migrations and update checklist
- Expand docs/testing.md: detailed test checklist for backend (routes, handlers, pipelines) and frontend plugs; map make test/check/check-all by scope and testing guidance
- Makefile change: add DC_LOCAL (docker compose -f compose.yaml -f compose.local.yaml) and use it in run-local so compose.local.yaml is applied alongside compose.yaml
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21678]: https://softwareone.atlassian.net/browse/MPT-21678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ