### PR TITLE
MPT-21980 Verify existing tag points to release commit

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -95,7 +95,12 @@ jobs:
         run: |
           set -euo pipefail
           if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-            echo "Tag '${VERSION}' already exists; skipping creation."
+            TAG_SHA="$(git rev-list -n1 "${VERSION}")"
+            if [ "${TAG_SHA}" != "${GITHUB_SHA}" ]; then
+              echo "::error::Tag '${VERSION}' already exists at '${TAG_SHA}', expected '${GITHUB_SHA}'."
+              exit 1
+            fi
+            echo "Tag '${VERSION}' already exists at current commit; skipping creation."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -126,7 +126,12 @@ jobs:
         run: |
           set -euo pipefail
           if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-            echo "Tag '${VERSION}' already exists; skipping creation."
+            TAG_SHA="$(git rev-list -n1 "${VERSION}")"
+            if [ "${TAG_SHA}" != "${GITHUB_SHA}" ]; then
+              echo "::error::Tag '${VERSION}' already exists at '${TAG_SHA}', expected '${GITHUB_SHA}'."
+              exit 1
+            fi
+            echo "Tag '${VERSION}' already exists at current commit; skipping creation."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Follow-up to the release pipeline templates (originally added in #79 / MPT-21980), addressing CodeRabbit feedback raised on the rollout PRs.

In both `release-library.yml` and `release-extension.yml`, the "Create annotated tag" step skipped creation when a tag for the version already existed — without checking which commit that tag pointed to. A pre-created or drifted tag could therefore cause the release to be cut from an unintended commit.

Now, if the tag already exists, the step verifies it points to the dispatched commit (`GITHUB_SHA`) and fails otherwise, instead of silently skipping.

## Note
The hard fail on an already-published GitHub *release* is kept intentionally (guard against re-releasing an existing version); resume of a partially-failed run is done via "Re-run failed jobs".

## Testing
- `pre-commit` (check-yaml + file hygiene) passes.

Relates to MPT-21980.
