### PR TITLE
MPT-22059 swo-extension-playground documentation fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Working protocol for any task in this repository:
 When applicable, read the repository in this order:
 
 1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
-2. [docs/architecture.md](docs/architecture.md) for the template architecture placeholder and future design notes.
+2. [docs/architecture.md](docs/architecture.md) for the repository structure and runtime components.
 3. [docs/local-development.md](docs/local-development.md) for local setup and service startup.
 4. [docs/deployment.md](docs/deployment.md) for configuration and runtime parameters.
 5. [docs/contributing.md](docs/contributing.md) for the repository workflow and expected developer commands.
@@ -28,6 +28,8 @@ Then inspect the code paths relevant to the task:
 - [`make/`](make): canonical commands used by the repository
 - [`Dockerfile`](Dockerfile) and [`compose.yaml`](compose.yaml): backend container and local stack
 - [`.github/workflows/pr-build-merge.yml`](.github/workflows/pr-build-merge.yml): CI checks
+- [`.github/workflows/release-extension.yml`](.github/workflows/release-extension.yml): manual release workflow for extensions (validate version, annotated tag, GitHub release, Dependency-Track)
+- [`.github/workflows/release-library.yml`](.github/workflows/release-library.yml): manual release workflow for libraries (build and publish to PyPI, annotated tag, GitHub release, Dependency-Track)
 
 Operational guidance:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,6 +52,15 @@ Use `make check-all` for the combined validation workflow. Most targets accept `
 
 See [docs/testing.md](testing.md) for repository-specific testing expectations.
 
+## Releases
+
+Releases are cut by manually dispatching a GitHub Actions workflow with the target version (`X.Y.Z`, no `v` prefix). The branch selected at dispatch time decides the release type: `main` produces a pre-release, a `release/*` branch produces the latest release. Each workflow validates the version (semver, no existing published release, greater than the latest reachable tag) and is safe to re-run.
+
+This repository is the extension/library template and ships both release workflows:
+
+- [`.github/workflows/release-extension.yml`](../.github/workflows/release-extension.yml): for extension repositories. Creates the annotated tag and the GitHub release and runs Dependency-Track; the container image is built by a separate external system.
+- [`.github/workflows/release-library.yml`](../.github/workflows/release-library.yml): for Python library repositories. Additionally builds and publishes the package to PyPI via OIDC trusted publishing. The PyPI trusted publisher is bound to the workflow filename, so keep the filename stable when adopting it.
+
 ## Documentation Changes
 
 When changing repository docs:


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Documentation fixes for swo-extension-playground (MPT-22059, under the doc-backfill story MPT-22048), addressing drift from the release-pipeline work.

- **AGENTS.md**: list the two release workflows (`release-extension.yml`, `release-library.yml`) alongside the CI workflow; fix the architecture pointer that still described `architecture.md` as a placeholder.
- **docs/contributing.md**: add a **Releases** section — manual dispatch with a version input, branch-driven pre-release (main) / latest (release/*), version guard, and the PyPI trusted-publishing note for the library workflow.

## Notes
- `docs/testing.md` already scopes `make check-all` metadata validation to `scope=all` (line 41) — no change needed.
- The "previous workflow was release.yml" comment in `release-library.yml` is intentional template guidance for adopting library repos — left as is.

## Testing
- pre-commit file-hygiene hooks pass on the changed docs.

Subtask: MPT-22059 (parent MPT-22048).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22059](https://softwareone.atlassian.net/browse/MPT-22059)

- Updated `AGENTS.md` to include release workflows (`release-extension.yml`, `release-library.yml`) in the task-read sequence
- Fixed `AGENTS.md` architecture pointer to correctly reference `docs/architecture.md` as describing repository structure and runtime components
- Added "Releases" section to `docs/contributing.md` documenting manual GitHub Actions dispatch with version input, branch-driven behavior (pre-release on main, latest on `release/*`), version guard, and PyPI trusted-publishing configuration for the library workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22059]: https://softwareone.atlassian.net/browse/MPT-22059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ