### PR TITLE
MPT-22073 generate frontend statics in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 WORKDIR /extension
 
+RUN uv venv /opt/venv
+
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+ENV PATH=/opt/venv/bin:$PATH
+
+FROM base AS build-base
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -9,35 +16,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN uv venv /opt/venv
-
-ENV UV_PROJECT_ENVIRONMENT=/opt/venv
-ENV PATH=/opt/venv/bin:$PATH
-
-FROM base AS build
+FROM build-base AS build
 
 COPY backend/ .
-RUN mkdir -p static
-COPY static/ ./static/
 
 RUN uv sync --frozen --no-cache --no-dev
 
+FROM node:24-bookworm-slim AS frontend-build
+
+WORKDIR /frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+RUN mkdir -p /static
+
 FROM build AS dev
 
+COPY --from=frontend-build /static ./static
 RUN uv sync --frozen --no-cache --dev
 
 CMD ["mpt-ext", "run"]
 
-FROM build AS prod
+FROM base AS prod
 
-RUN rm -rf tests/
-
-RUN apt-get update && apt-get purge -y --auto-remove \
-    gcc \
-    g++ \
-    git \
-    python3-dev \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /opt/venv /opt/venv
+COPY --from=build /extension/swo_playground ./swo_playground
+COPY --from=build /extension/migrations ./migrations
+COPY --from=frontend-build /static ./static
 
 RUN groupadd -r appuser && useradd -r -g appuser -m -d /home/appuser appuser && \
     mkdir -p /home/appuser/.cache/uv && \


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Jira: https://softwareone.atlassian.net/browse/MPT-22073
Parent: https://softwareone.atlassian.net/browse/MPT-22072

## What was done

- Added a dedicated frontend build stage to generate static plug assets during Docker builds.
- Split OS build tooling into a `build-base` stage so apt packages stay cached independently from backend dependency changes.
- Made both `dev` and `prod` copy generated statics from `frontend-build`; `docker run` works with baked statics, while Docker Compose can still override `/extension/static` with the local volume for dynamic reload.
- Made `prod` copy only runtime artifacts and generated statics instead of inheriting tests, stale static files, or build tool layers.
- Kept the frontend stage robust by ensuring `/static` exists after build.

## Testing

- `docker build --target prod -t swo-extension-playground:prod-static-check .`
- `docker build --target dev -t swo-extension-playground:dev-static-check .`
- Runtime prod checks: package import, `/extension/tests` absent, generated JS present under `/extension/static`, and `gcc`/`g++`/`git` absent.
- Runtime dev checks: generated statics present under `/extension/static` when the dev image is run directly.
- Previous full validation on this PR: backend/frontend checks, backend/frontend tests, frontend build, and metadata generation/validation via `docker compose run --rm --no-deps ...`.

Note: `make build` started the documented flow and built the backend image, but the final `docker compose run backend uv sync` step could not start because local port `4318` is already allocated by `mpt-installation-extension-jaeger-1`. The equivalent checks were run with `--no-deps` to avoid stopping another local project service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22073](https://softwareone.atlassian.net/browse/MPT-22073)

- Add dedicated frontend-build multi-stage Docker stage to generate frontend static assets during image build; uses node:24-bookworm-slim, runs npm ci and npm run build to produce /static and ensures /static exists after build
- Introduce base stage centralizing Python venv creation at /opt/venv and build-base stage for OS build dependencies (gcc, g++, git, python3-dev)
- build stage installs frozen Python deps via uv sync; dev stage runs uv sync with --dev and copies /static from frontend-build
- prod stage now starts FROM base (clean runtime image), copies only runtime artifacts (Python venv, extension runtime dirs like swo_playground and migrations) from build and /static from frontend-build — avoids inheriting build/test layers or stale static files
- Remove previous prod-stage cleanup/purge steps; production image is smaller and contains only runtime artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22073]: https://softwareone.atlassian.net/browse/MPT-22073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ