### PR TITLE
MPT-22216 Add explicit rootDir to frontend tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,8 @@
     "outDir": "../static/types",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add `"rootDir": "src"` to `compilerOptions` in [`frontend/tsconfig.json`](frontend/tsconfig.json).

## Why

The frontend watch (`tsc` run against `tsconfig.json`, used by `make run-local`) failed with **TS5011** under TypeScript 6:

```
tsconfig.json: error TS5011: The common source directory of 'tsconfig.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
```

The config emits declarations to `../static/types` (`outDir` / `declarationDir`), a directory **outside** the project root. When the emit target is outside the project, TypeScript 6 no longer infers the source root silently and requires an explicit `rootDir`. Setting it to `src` makes the source root explicit and keeps the emitted layout under `static/types` clean (no extra `src/` nesting).

Note: the production build (`tsconfig.build.json`) already overrode `rootDir`, so only the watch config (`tsconfig.json`) was affected — which is why `make build` passed while the watch failed.

## Testing

- `make check-all scope=frontend` → passed (exit 0): checks, tests, and frontend build.

Closes MPT-22216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22216](https://softwareone.atlassian.net/browse/MPT-22216)

- Added `compilerOptions.rootDir: "src"` to `frontend/tsconfig.json` to fix TypeScript 6 `TS5011`
- Unblocked the frontend watch process (`tsc` via `make run-local`) by making the source root explicit for declaration output
- Matched behavior with `tsconfig.build.json` and preserved the intended `static/types` output structure
- Validated with `make check-all scope=frontend` (checks/tests/builds passed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22216]: https://softwareone.atlassian.net/browse/MPT-22216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ