### PR TITLE
MPT-22227 document playground run steps and runner differences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,19 +12,24 @@ When applicable, read the repository in this order:
 
 1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
 2. [docs/architecture.md](docs/architecture.md) for the repository structure and runtime components.
-3. [docs/local-development.md](docs/local-development.md) for local setup and service startup.
-4. [docs/deployment.md](docs/deployment.md) for configuration and runtime parameters.
-5. [docs/contributing.md](docs/contributing.md) for the repository workflow and expected developer commands.
-6. [docs/testing.md](docs/testing.md) before changing code or tests.
-7. [docs/migrations.md](docs/migrations.md) when a task mentions schema or data migrations.
-8. [docs/documentation.md](docs/documentation.md) when changing repository documentation.
+3. [docs/examples.md](docs/examples.md) for a tour of the example API, events, pipelines, context, and plugs.
+4. [docs/local-development.md](docs/local-development.md) for local setup and service startup.
+5. [docs/deployment.md](docs/deployment.md) for configuration and runtime parameters.
+6. [docs/contributing.md](docs/contributing.md) for the repository workflow and expected developer commands.
+7. [docs/testing.md](docs/testing.md) before changing code or tests.
+8. [docs/migrations.md](docs/migrations.md) when a task mentions schema or data migrations.
+9. [docs/documentation.md](docs/documentation.md) when changing repository documentation.
 
 Then inspect the code paths relevant to the task:
 
 - [`backend/swo_playground/app.py`](backend/swo_playground/app.py): Extension SDK application entry point
+- [`backend/swo_playground/settings.py`](backend/swo_playground/settings.py): extension settings and required environment variables
 - [`backend/pyproject.toml`](backend/pyproject.toml): backend dependencies, lint, test, and type-check configuration
 - [`backend/migrations/`](backend/migrations/): migration files managed by `mpt-tool`
 - [`backend/tests/`](backend/tests/): backend test suite
+- [`frontend/src/modules/`](frontend/src/modules/): React plug entry points (one bundle per module)
+- [`frontend/src/shared/`](frontend/src/shared/): shared frontend components, hooks, and model helpers
+- [`frontend/esbuild.config.js`](frontend/esbuild.config.js): frontend build that emits plug bundles into `static/`
 - [`make/`](make): canonical commands used by the repository
 - [`Dockerfile`](Dockerfile) and [`compose.yaml`](compose.yaml): backend container and local stack
 - [`.github/workflows/pr-build-merge.yml`](.github/workflows/pr-build-merge.yml): CI checks

--- a/README.md
+++ b/README.md
@@ -43,12 +43,22 @@ Shared meaning of common make targets is documented in:
 ## Documentation
 
 - [AGENTS.md](AGENTS.md): entry point for AI agents
-- [docs/architecture.md](docs/architecture.md): architecture placeholder for future repository-specific design
+- [docs/architecture.md](docs/architecture.md): stable backend and frontend components, entry points, and data flow
+- [docs/examples.md](docs/examples.md): guided tour of the example API, events, pipelines, context, and plugs
 - [docs/contributing.md](docs/contributing.md): repository-specific development workflow
-- [docs/local-development.md](docs/local-development.md): local setup and service startup
+- [docs/local-development.md](docs/local-development.md): local setup, run modes, and runner differences
 - [docs/deployment.md](docs/deployment.md): runtime configuration and deployment-facing settings
 - [docs/testing.md](docs/testing.md): testing strategy and commands
 - [docs/migrations.md](docs/migrations.md): migration workflow and current constraints
 - [docs/documentation.md](docs/documentation.md): repository documentation rules
 
 Keep repository-specific workflow details in the documents under [`docs/`](docs/), not in this file.
+
+## SDK References
+
+This repository builds on SDKs documented in their own repositories. For library
+APIs, prefer those guides over duplicating them here:
+
+- Backend (Extension SDK): [`mpt-extension-sdk`](https://github.com/softwareone-platform/mpt-extension-sdk) — see [`docs/usage.md`](https://github.com/softwareone-platform/mpt-extension-sdk/blob/main/docs/usage.md) and [`docs/sdk_usage/`](https://github.com/softwareone-platform/mpt-extension-sdk/tree/main/docs/sdk_usage).
+- Frontend (UI SDK): [`mpt-extension-ui-sdk`](https://github.com/softwareone-platform/mpt-extension-ui-sdk) — `@mpt-extension/sdk` and `@mpt-extension/sdk-react`.
+- Frontend (UI component library): [`@softwareone-platform/sdk-react-ui-v0`](https://www.npmjs.com/package/@softwareone-platform/sdk-react-ui-v0).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,13 +7,19 @@ This repository is a small Marketplace extension playground. It is intentionally
 ## Runtime Components
 
 - `backend/swo_playground/app.py` creates the `ExtensionApp` and registers all routers.
+- `backend/swo_playground/settings.py` defines `ExtensionSettings` and the required environment variables (for example `MPT_PRODUCTS_IDS`).
 - `backend/swo_playground/routers/api/` exposes extension API endpoints.
 - `backend/swo_playground/routers/events/` declares Marketplace event handlers.
 - `backend/swo_playground/flows/pipelines/` contains simple order and agreement pipelines.
 - `backend/swo_playground/flows/steps/` contains reusable pipeline steps.
+- `backend/swo_playground/context/` contains context adapters (for example `EventAgreementContext`) used by pipelines.
 - `backend/swo_playground/routers/plugs/` declares Marketplace Portal plug metadata.
 - `frontend/src/modules/` contains the React plug entry points.
 - `static/` contains generated frontend bundles served by the backend.
+
+This document covers how the backend and frontend layers fit together in *this*
+repository; for the SDK APIs themselves, see the SDK references in
+[README.md](../README.md).
 
 ## Entry Points
 
@@ -31,6 +37,29 @@ Agreement API handlers read Marketplace agreement data through the SDK API servi
 Event handlers receive Marketplace event payloads, log the event context, and execute a small pipeline. The pipelines are deliberately simple examples and should remain focused on extension-layer behavior rather than SDK internals.
 
 Portal plugs are declared by backend metadata. The frontend build writes JavaScript bundles into `static/`; those bundles are referenced by plug `href` values and mounted into the backend container.
+
+## Frontend
+
+The frontend follows a small set of conventions:
+
+- **Plugs**: each directory under `frontend/src/modules/<name>/` is a plug with an
+  `index.tsx` entry point. The esbuild config ([`frontend/esbuild.config.js`](../frontend/esbuild.config.js))
+  discovers these entry points by convention and emits one IIFE bundle per module
+  into `static/<name>/index.js`. The bundle filename must match the `href` in the
+  plug metadata, or MPT cannot load the iframe.
+- **Shared layer**: `frontend/src/shared/` holds reusable building blocks —
+  `components/` (presentational UI), `hooks/` (for example `useAgreement`, which
+  fetches `/api/v2/agreements/{id}` through the SDK `http` client and exposes
+  load/error/ready states), and `model.ts` (response types and formatters).
+- **Build output**: the build emits bundles plus sourcemaps, and TypeScript
+  declarations under `static/types/`.
+
+The static-asset bridge is the contract between the layers: the frontend writes
+into `static/`, the backend serves it at `/static`, and the dev/prod image stages
+differ in whether `static/` is bind-mounted or baked in (see
+[docs/deployment.md](deployment.md)). For the iframe-specific styling shims under
+`frontend/src/fixes/`, see the code comments — they are expected to shrink as the
+UI SDK evolves and are intentionally not documented here yet.
 
 ## Persistence And Migrations
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,6 +50,8 @@ make test
 
 Use `make check-all` for the combined validation workflow. Most targets accept `scope=backend`, `scope=frontend`, or `scope=all`; the default is `all`.
 
+`make review` runs a CodeRabbit review in interactive mode (configured by [`.coderabbit.yaml`](../.coderabbit.yaml)); pass `args=<options>` to override or extend it.
+
 See [docs/testing.md](testing.md) for repository-specific testing expectations.
 
 ## Releases

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,11 +16,23 @@ Docker Compose reads:
 
 Local setup instructions live in [docs/local-development.md](local-development.md).
 
+## Extension Identity
+
+These settings identify the extension instance to the SDK runtime and the
+Marketplace. They are present in `backend/.env.sample` and are required for the
+extension to register and authenticate.
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `SDK_EXTENSION_API_KEY` | - | `<extension-api-key>` | API key used for extension registration and runtime task operations |
+| `SDK_EXTENSION_ID` | - | `EXT-1111-1111` | Extension identifier used during instance registration |
+| `SDK_EXTENSION_URL` | - | `https://extensions.example.com` | Extension registration endpoint used during platform startup (points at `devmock` in local mock mode) |
+
 ## Core Application Settings
 
 | Environment Variable | Default | Example | Description |
 | --- | --- | --- | --- |
-| `MPT_API_BASE_URL` | `http://localhost:8000` | `https://api.platform.softwareone.com` | SoftwareOne Marketplace API URL |
+| `MPT_API_BASE_URL` | - | `https://api.platform.softwareone.com` | SoftwareOne Marketplace API URL, required by the runtime (use `http://devmock:8000` in local mock mode) |
 | `MPT_PRODUCTS_IDS` | `PRD-1111-1111` | `PRD-1234-1234,PRD-4321-4321` | Comma-separated list of Marketplace product ids |
 | `MPT_TOOL_STORAGE_TYPE` | `local` | `airtable` | Storage type for MPT tools |
 | `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXXXXXXXX` | Airtable API key when Airtable storage is enabled |
@@ -37,11 +49,27 @@ Local setup instructions live in [docs/local-development.md](local-development.m
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | - | `InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/` | Azure Application Insights connection string |
 | `OTEL_SERVICE_NAME` | - | `Swo.Extensions.<ServiceName>` | Service name shown in telemetry |
 
+## Required Configuration By Run Mode
+
+The minimum settings depend on the runner used in
+[docs/local-development.md](local-development.md):
+
+- **`make run` (platform integration)**: reads `backend/.env` (optional for
+  Compose, but the extension needs real values). Set at least `MPT_PRODUCTS_IDS`,
+  `MPT_API_BASE_URL`, and the `SDK_EXTENSION_API_KEY` / `SDK_EXTENSION_ID` /
+  `SDK_EXTENSION_URL` values for the target Marketplace.
+- **`make run-local` (mock mode)**: requires `backend/.env.local`. The
+  `SDK_EXTENSION_*` and `MPT_API_BASE_URL` values point at the local `devmock`
+  service.
+
 ## Local Example
 
 Example `backend/.env` snippet for platform integration:
 
 ```env
+SDK_EXTENSION_API_KEY=<extension-api-key>
+SDK_EXTENSION_ID=EXT-1111-1111
+SDK_EXTENSION_URL=https://extensions.example.com
 MPT_API_BASE_URL=https://api.s1.show
 MPT_ORDERS_API_POLLING_INTERVAL_SECS=120
 MPT_PRODUCTS_IDS=PRD-1111-1111,PRD-2222-2222
@@ -54,6 +82,9 @@ MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME=<airtable-table-name>
 Example `backend/.env.local` snippet for devmock local mode:
 
 ```env
+SDK_EXTENSION_API_KEY=<extension-api-key>
+SDK_EXTENSION_ID=EXT-1111-1111
+SDK_EXTENSION_URL=http://devmock:8000
 MPT_API_BASE_URL=http://devmock:8000
 MPT_PRODUCTS_IDS=PRD-1111-1111
 MPT_TOOL_STORAGE_TYPE=local
@@ -65,4 +96,16 @@ The `MPT_TOOL_STORAGE_*` variables mirror the storage configuration documented i
 
 ## Static Assets
 
-Frontend plug bundles are generated into `static/` and mounted into the backend container at `/extension/static`. Plug metadata references these bundles with `/static/...` hrefs.
+Frontend plug bundles are generated into `static/` and served by the backend at
+`/static`. Plug metadata references these bundles with `/static/...` hrefs. The
+build also emits TypeScript declarations into `static/types/`.
+
+How `static/` reaches the backend depends on the image stage in
+[`Dockerfile`](../Dockerfile):
+
+- **dev** (used by `compose.yaml`): `static/` is bind-mounted into the backend
+  container at `/extension/static`, so the frontend watcher's output is picked up
+  live.
+- **prod**: the bundles are built in the `frontend-build` stage and baked into
+  the image, so the production container ships its own `static/` and runs as a
+  non-root user.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -19,6 +19,7 @@ This file documents repository-specific documentation rules only.
 - [`README.md`](../README.md): human entry point, overview, quick start, and documentation map
 - [`AGENTS.md`](../AGENTS.md): AI entry point and reading order
 - [`architecture.md`](architecture.md): stable runtime components, entry points, and data flow
+- [`examples.md`](examples.md): guided tour of the example API, events, pipelines, context, and plugs
 - [`local-development.md`](local-development.md): Docker, local mock mode, frontend watch, and environment file usage
 - [`deployment.md`](deployment.md): runtime configuration and deployment model
 - [`contributing.md`](contributing.md): repository-specific development workflow

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,116 @@
+# Examples
+
+This repository is a playground: the code under `backend/swo_playground/` and
+`frontend/src/` is a set of small, working examples of the extension building
+blocks. This document is a guided tour of those examples and where to find them.
+
+It describes *what this repository demonstrates*, not the SDK APIs themselves.
+For the library APIs, see the SDK usage guides linked from [README.md](../README.md).
+
+## Trying It With Postman
+
+[`backend/docs/postman_collection.json`](../backend/docs/postman_collection.json)
+is a ready-made Postman collection for a locally running backend (default
+`base_url` `http://localhost:8080`, the port exposed by `make run-local`). Auth
+is wired automatically through a collection-level pre-request script. It contains
+sample requests for the example routes below — `/health`, the order and agreement
+events, and the agreement API (including list pagination, get, not-found, and
+sync) — so you can exercise the playground without writing requests by hand.
+
+## Application Wiring
+
+[`backend/swo_playground/app.py`](../backend/swo_playground/app.py) creates the
+`ExtensionApp` and registers every example router:
+
+- `events_orders_router` — order event handling
+- `events_agreements_router` — agreement event handling
+- `api_agreements_router` — agreement API endpoints
+- `plug_agreements_router` — Marketplace Portal plugs
+
+Each router below is an independent example and can be read on its own.
+
+## API Endpoints
+
+[`backend/swo_playground/routers/api/agreement.py`](../backend/swo_playground/routers/api/agreement.py)
+exposes an `APIRouter` under `/api/v2/agreements`:
+
+| Route | Name | Demonstrates |
+| --- | --- | --- |
+| `GET /` | `agreements-list` | Paginated reads with `ctx.request.pagination` and `PaginatedResult` / `APIResponse.paginated` |
+| `GET /{agreement_id}` | `agreements-get` | Reading a single agreement via `ctx.mpt_api_service` and returning `APIResponse.ok` |
+| `POST /{agreement_id}/sync` | `agreements-sync` | A write-style action that re-reads current Marketplace data |
+
+These handlers read Marketplace data through `ctx.mpt_api_service.agreements`.
+The `sync` route is the backend half of the frontend "Sync now" example (see
+[Plugs](#plugs)).
+
+## Events
+
+The playground shows the two event styles supported by the SDK:
+
+- **Task event** —
+  [`routers/events/order.py`](../backend/swo_playground/routers/events/order.py)
+  registers `@orders_router.task("/purchase")` for
+  `platform.commerce.order.status_changed`, filtered by a `condition` on the
+  configured `product.id`s. It receives a standard `OrderContext` and runs the
+  `PurchasePipeline`.
+- **Non-task event with a custom context** —
+  [`routers/events/agreement.py`](../backend/swo_playground/routers/events/agreement.py)
+  registers `@agreements_router.event("/complete")` for
+  `platform.commerce.agreement.status_changed`, with a richer condition
+  (`...,eq(status,Active)`) and a `context_adapter_type=EventAgreementContext`. It
+  runs the `CompleteAgreementPipeline`.
+
+Both conditions are built from `get_extension_settings().product_ids`, showing
+how event registration uses extension settings.
+
+## Pipelines And Steps
+
+Event handlers delegate to small pipelines, demonstrating the
+pipeline/step composition pattern:
+
+- [`flows/pipelines/orders/purchase.py`](../backend/swo_playground/flows/pipelines/orders/purchase.py)
+  (`PurchasePipeline`) → [`flows/steps/log_order.py`](../backend/swo_playground/flows/steps/log_order.py)
+  (`LogOrderStep`, logs the order id).
+- [`flows/pipelines/agreements/complete.py`](../backend/swo_playground/flows/pipelines/agreements/complete.py)
+  (`CompleteAgreementPipeline`) → [`flows/steps/log_agreement.py`](../backend/swo_playground/flows/steps/log_agreement.py)
+  (`LogAgreementStep`, logs the agreement id and the custom context field).
+
+A pipeline is a `BasePipeline` whose `steps` property returns an ordered list of
+`BaseStep`s. The steps here only log, on purpose — they are the place real
+fulfillment logic would go.
+
+## Custom Context
+
+[`backend/swo_playground/context/agreement.py`](../backend/swo_playground/context/agreement.py)
+defines `EventAgreementContext`, an example context adapter that extends the SDK
+`AgreementContext` with an extra `mock_field` and overrides `from_context`. It is
+wired into the agreement event (`context_adapter_type=...`) and consumed by
+`LogAgreementStep`, showing how to carry extension-specific data through a
+pipeline.
+
+## Plugs
+
+[`backend/swo_playground/routers/plugs/agreements.py`](../backend/swo_playground/routers/plugs/agreements.py)
+declares three Marketplace Portal plugs through a `PlugRouter`. Each plug points
+at a frontend bundle via `href` and binds to a Portal `socket`. The frontend
+module names match the bundle paths one-to-one:
+
+| Plug id / socket | Frontend module | Demonstrates |
+| --- | --- | --- |
+| `agreements-agreement` — `portal.commerce.agreements.agreement` | [`modules/agreements-agreement/`](../frontend/src/modules/agreements-agreement/) | A full agreement tab: sync status, `useAgreementSync`, status chips, and a "Sync now" action calling the `sync` API |
+| `agreements-line-actions` — `portal.commerce.agreements.line.actions` | [`modules/agreements-line-actions/`](../frontend/src/modules/agreements-line-actions/) | A modal (`useMPTModal`) that renders agreement details with a Close action |
+| `agreements-agreement-actions` — `portal.commerce.agreements.agreement.actions` | [`modules/agreements-agreement-actions/`](../frontend/src/modules/agreements-agreement-actions/) | A multi-step `Wizard` that reviews agreement details (read-only) |
+
+Each module's `index.tsx` follows the same entry-point pattern: import the
+`safe-storage` shim, call `setup()` from `@mpt-extension/sdk`, and mount the
+`App` with `createRoot`. The shared building blocks they reuse (`useAgreement`,
+`useAgreementId`, `AgreementDetailsList`, `model.ts`) live under
+[`frontend/src/shared/`](../frontend/src/shared/); see
+[docs/architecture.md](architecture.md#frontend) for the frontend structure.
+
+## Migrations
+
+[`backend/migrations/`](../backend/migrations/) contains example data and schema
+migrations. They are intentionally fake placeholders; see
+[docs/migrations.md](migrations.md).

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -22,42 +22,102 @@ make build scope=backend
 make build scope=frontend
 ```
 
-## Running the Service
+## How the Extension Runs
 
-Start the service in platform integration mode:
+This repository is a single extension with two layers that meet at the
+repository-level `static/` folder: the backend (Extension SDK) serves that
+folder at `/static`, and the frontend build writes plug bundles into it. Before
+the backend can register plugs, `static/` must already contain the bundles their
+metadata references, so the run order is always:
 
-```bash
-make run
-```
+1. `make build` generates the frontend bundles into `static/`.
+2. A runner (`make run` or `make run-local`) starts the backend, which mounts
+   `static/` at `/static` and exposes the extension.
 
-`make run` starts backend, frontend, and Jaeger when `scope=all`. Use scoped startup when needed:
+The two runners differ in *what* the backend connects to and *whether* the plug
+is rendered inside the Marketplace Portal (MPT).
 
-```bash
-make run scope=backend
-make run scope=frontend
-```
+## Choosing a Runner
 
-The frontend container watches `frontend/` and writes generated plug assets into `static/`.
+| | `make run-local` | `make run` |
+| --- | --- | --- |
+| Purpose | Local development runtime | Platform integration: validate real plug behavior inside MPT |
+| Backend command | `mpt-ext run --local` (FastAPI + uvicorn) | `mpt-ext run` (registers the instance, platform runtime) |
+| Compose files | `compose.yaml` + `compose.local.yaml` | `compose.yaml` |
+| Extra services | `devmock` (WireMock) + Jaeger | Jaeger |
+| Marketplace API | mocked by `devmock` | real Marketplace |
+| Required config | `backend/.env.local` (**required**) | `backend/.env` with real Marketplace settings |
+| `/static` | served; confirms a bundle is reachable | served and loaded by MPT inside the plug iframe |
+| Renders the plug in MPT? | No — only proves the asset is reachable | Yes — real socket, context, modal, events, auth |
 
-## Local Mock Mode
+Use `make run-local` for day-to-day development without a real Marketplace.
+`make run` is the only mode that exercises the full plug UI inside MPT.
 
-For local development without a real Marketplace API, use:
+### `make run-local` (local mock mode)
 
 ```bash
 make run-local
 ```
 
-This runs the backend with `mpt-ext run --local` and starts the WireMock devmock service from `compose.local.yaml`. The extension service is exposed on `http://localhost:8080`; the devmock service listens on `http://localhost:8000` and uses mappings under `peripherals/devmock/`.
+Runs the backend with `mpt-ext run --local` and starts the WireMock `devmock`
+service from `compose.local.yaml`. The extension is exposed on
+`http://localhost:8080`; `devmock` listens on `http://localhost:8000` and uses
+the mappings under `peripherals/devmock/`. This mode **requires**
+`backend/.env.local` (see [Required Configuration](#required-configuration)).
 
-Local mock mode requires `backend/.env.local`. The sample values in `backend/.env.sample` show the expected local devmock shape.
-
-Useful helper commands:
+### `make run` (platform integration)
 
 ```bash
-make bash
-make down
-make logs
+make run
 ```
+
+Runs the backend with `mpt-ext run`, which registers the extension instance and
+exposes its routes and `/static` assets to MPT. This is the mode that renders
+the plug inside the Portal, so it needs a `backend/.env` pointing at a real
+Marketplace.
+
+## Scopes
+
+`run` and `run-local` accept `scope=backend|frontend|all` (default `all`). An
+invalid value fails fast with `Invalid scope '<x>'. Use one of: backend
+frontend all`.
+
+| Scope | What starts | Notes |
+| --- | --- | --- |
+| `all` (default) | backend + frontend watcher + Jaeger (+ `devmock` in local mode) | Runs **detached** (`-d`); the terminal returns immediately |
+| `backend` | backend (+ Jaeger by dependency) | Runs in the **foreground**; no frontend watcher, so bundles are not rebuilt |
+| `frontend` | frontend watcher only | Runs in the **foreground**; rebuilds bundles into `static/` but has no backend, so calls to `/api/v2/agreements` will not respond |
+
+The frontend watcher (`scope=frontend` or `all`) watches `frontend/` and
+regenerates plug bundles into `static/` on change. In `make run-local`, the
+`devmock` service starts as a backend dependency for any scope that starts the
+backend.
+
+## Required Configuration
+
+The minimum environment needed depends on the runner. The full parameter
+reference lives in [docs/deployment.md](deployment.md); do not duplicate it here.
+
+- **`make run-local`**: `backend/.env.local` is **required** (`compose.local.yaml`
+  declares it `required: true`). `backend/.env.sample` shows the expected shape,
+  including the `SDK_EXTENSION_*` values and `MPT_API_BASE_URL=http://devmock:8000`.
+- **`make run`**: `backend/.env` is optional for Compose to start the container,
+  but the extension needs real Marketplace settings to integrate — at minimum
+  `MPT_PRODUCTS_IDS` (enforced by [`settings.py`](../backend/swo_playground/settings.py)),
+  `MPT_API_BASE_URL`, and the `SDK_EXTENSION_API_KEY` / `SDK_EXTENSION_ID` /
+  `SDK_EXTENSION_URL` values for the target Marketplace.
+
+## Operating a Detached Run
+
+Because `scope=all` runs detached, use these helpers to observe and stop it:
+
+```bash
+make logs    # follow backend + frontend logs (scope-aware)
+make down    # stop and remove the containers
+make bash    # open an interactive backend shell
+```
+
+Jaeger traces are available at `http://localhost:16686` (OTLP ingest on `4318`).
 
 ## Environment Parameters
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,7 @@ Repository command mapping:
 - `make check scope=frontend` runs `tsc --noEmit` and `eslint`
 - `make check-all` runs checks, tests, frontend build, and metadata generation/validation for `scope=all`
 
-The CI workflow in [`.github/workflows/pr-build-merge.yml`](../.github/workflows/pr-build-merge.yml) uses the same `make build` and `make check-all` flow.
+The CI workflow in [`.github/workflows/pr-build-merge.yml`](../.github/workflows/pr-build-merge.yml) uses the same `make build` and `make check-all` flow, and additionally runs a SonarCloud/SonarQube scan (`SONAR_TOKEN`) as a quality gate that can block the pull request.
 
 ## Pytest Configuration
 
@@ -61,6 +61,19 @@ Repository-specific guidance:
 - Keep frontend tests close to the component, hook, or model module they cover.
 - Use generated devmock payloads only as stable examples; do not depend on live Marketplace services.
 - Follow the shared unit-test standard for AAA structure, parametrization, mocking rules, deterministic behavior, and coverage expectations.
+
+## Frontend Tests
+
+Frontend tests run with Jest + Testing Library (`make test scope=frontend`).
+Repository-specific patterns:
+
+- Co-locate tests with the module they cover (`App.test.tsx`, `*.test.ts` next to
+  the component, hook, or model under `frontend/src/`).
+- Mock the SDK HTTP client (`http` from `@mpt-extension/sdk`) instead of hitting a
+  backend; assert on rendered output and load/error states.
+- Reuse shared fixtures from [`frontend/src/shared/test-utils/`](../frontend/src/shared/test-utils/)
+  (for example `agreement-mocks.ts`) rather than redefining agreement payloads.
+- Render components with Testing Library and query by accessible roles/labels.
 
 ## When Tests Are Required
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Documentation-only change focused on how to run the playground and what it demonstrates.

- **Run steps & runners** (`docs/local-development.md`): a how-it-runs flow plus a `make run` vs `make run-local` comparison (purpose, services, mocked vs real Marketplace, whether the plug renders inside MPT), scope behavior (detached `all` vs foreground `backend`/`frontend`, what stops working), a Required Configuration section per mode, and `logs`/`down`/Jaeger UI.
- **Environment reference** (`docs/deployment.md`): adds the missing `SDK_EXTENSION_*` settings, a "required configuration by run mode" note, completed `.env`/`.env.local` examples, and the dev/prod Docker static-asset model.
- **Examples catalog** (`docs/examples.md`, new): guided tour of the example API endpoints, task vs non-task events, pipelines/steps, the custom context adapter, and the three plugs (with their frontend modules), plus a pointer to the `backend/docs/postman_collection.json` collection for exercising the example routes.
- **Frontend distributed into existing docs** (no separate `docs/frontend.md`): frontend component overview in `architecture.md`, frontend test pattern in `testing.md`.
- **Smaller fixes**: SonarCloud CI gate in `testing.md`, CodeRabbit `make review` in `contributing.md`, SDK references and doc links in `README`/`AGENTS`, and the new doc wired into the documentation map.

The iframe `fixes/` are intentionally left undocumented (expected to shrink with UI SDK updates; separate PR).

## Why

The execution docs did not explain the difference between the runners, the scope startup behavior, or the minimum configuration needed, and the example code had no guided reference.

## Testing

Documentation-only change; no code paths affected. Pre-commit hooks passed; tests are not required for docs-only changes per `docs/testing.md`. Verified that all file paths referenced by the new/updated docs exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Added `docs/local-development.md` with detailed guidance for running the playground, including `make run` (detached + mocked Marketplace) vs `make run-local` (foreground + real Marketplace), scope behavior, required env per mode, and how to manage logs/services/Jaeger
- Added `docs/examples.md` as a guided tour of example endpoints, task vs non-task events, pipeline/step composition, custom context adapter usage, and plugs with their frontend modules
- Expanded `docs/deployment.md` with missing `SDK_EXTENSION_*` environment variables, clearer run-mode configuration requirements, complete `.env`/`.env.local` examples, and documentation of the dev/prod static-asset model
- Updated frontend documentation distribution by enhancing `docs/architecture.md` (frontend plug/module conventions and static-asset bridge) and `docs/testing.md` (frontend Jest + Testing Library patterns)
- Additional documentation updates: `docs/testing.md` (SonarCloud CI gate), `docs/contributing.md` (`make review`), `docs/migrations.md` (migration command mapping), `README.md` (SDK references + doc links), and `AGENTS.md` (updated reading order and relevant code paths), with the new docs wired into the documentation map

All changes are documentation-only; no code was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->