### PR TITLE
MPT-22857 Add UI SDK frontend showcase to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `swo-extension-playground` is a minimal SoftwareOne Marketplace extension built on top of `mpt-extension-sdk` and `mpt-tool`.
 
-It is primarily a playground repository: it shows the baseline extension shape, agreement API endpoints, order and agreement event listeners, small fulfillment pipelines, Marketplace Portal plugs, and the development workflow used by extension repositories in this ecosystem.
+It is primarily a playground repository: it shows the baseline extension shape, agreement API endpoints, order and agreement event listeners, small fulfillment pipelines, Marketplace Portal plugs (including a UI SDK showcase — an examples app, a guide, and per-socket plug demos), and the development workflow used by extension repositories in this ecosystem.
 
 ## Repository Layout
 

--- a/backend/swo_playground/app.py
+++ b/backend/swo_playground/app.py
@@ -3,10 +3,22 @@ from mpt_extension_sdk import ExtensionApp
 from swo_playground.routers.api.agreement import agreements_router as api_agreements_router
 from swo_playground.routers.events.agreement import agreements_router as events_agreements_router
 from swo_playground.routers.events.order import orders_router as events_orders_router
+from swo_playground.routers.plugs.accounts import accounts_router as plug_accounts_router
 from swo_playground.routers.plugs.agreements import agreements_router as plug_agreements_router
+from swo_playground.routers.plugs.assets import assets_router as plug_assets_router
+from swo_playground.routers.plugs.orders import orders_router as plug_orders_router
+from swo_playground.routers.plugs.portal import portal_router as plug_portal_router
+from swo_playground.routers.plugs.subscriptions import (
+    subscriptions_router as plug_subscriptions_router,
+)
 
 ext_app = ExtensionApp(prefix="", version="6.0.0")
 ext_app.include_router(events_orders_router)
 ext_app.include_router(events_agreements_router)
 ext_app.include_router(api_agreements_router)
+ext_app.include_router(plug_portal_router)
 ext_app.include_router(plug_agreements_router)
+ext_app.include_router(plug_orders_router)
+ext_app.include_router(plug_subscriptions_router)
+ext_app.include_router(plug_assets_router)
+ext_app.include_router(plug_accounts_router)

--- a/backend/swo_playground/routers/plugs/accounts.py
+++ b/backend/swo_playground/routers/plugs/accounts.py
@@ -1,0 +1,14 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+from swo_playground.routers.plugs.common import add_plug
+
+accounts_router = PlugRouter()
+
+
+@accounts_router.register()
+def account_plugs() -> list[Plug]:
+    """Declare the `add` showcase plugs for the accounts sockets."""
+    return [
+        add_plug("portal.accounts.sellers.seller.actions"),
+    ]

--- a/backend/swo_playground/routers/plugs/agreements.py
+++ b/backend/swo_playground/routers/plugs/agreements.py
@@ -1,6 +1,8 @@
 from mpt_extension_sdk.routing import PlugRouter
 from mpt_extension_sdk.routing.plugs import Plug
 
+from swo_playground.routers.plugs.common import add_plug
+
 agreements_router = PlugRouter()
 
 
@@ -29,4 +31,5 @@ def agreement_plugs() -> list[Plug]:
             socket="portal.commerce.agreements.agreement.actions",
             href="/static/agreements-agreement-actions/index.js",
         ),
+        add_plug("portal.commerce.agreements.actions"),
     ]

--- a/backend/swo_playground/routers/plugs/assets.py
+++ b/backend/swo_playground/routers/plugs/assets.py
@@ -1,0 +1,17 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+from swo_playground.routers.plugs.common import add_plug
+
+assets_router = PlugRouter()
+
+
+@assets_router.register()
+def asset_plugs() -> list[Plug]:
+    """Declare the `add` showcase plugs for the asset sockets."""
+    return [
+        add_plug("portal.commerce.assets.actions"),
+        add_plug("portal.commerce.assets.line.actions"),
+        add_plug("portal.commerce.assets.asset"),
+        add_plug("portal.commerce.assets.asset.actions"),
+    ]

--- a/backend/swo_playground/routers/plugs/common.py
+++ b/backend/swo_playground/routers/plugs/common.py
@@ -1,0 +1,19 @@
+from mpt_extension_sdk.routing.plugs import Plug
+
+
+def add_plug(socket: str) -> Plug:
+    """Build an `add` showcase plug for a single socket.
+
+    Each socket has its own thin frontend module (``src/modules/add-<socket
+    dashed>``) built to ``/static/add-<socket dashed>/index.js``. The plug id,
+    the module directory and the bundle path all derive from the socket the
+    same way, so there is no separate socket manifest to keep in sync.
+    """
+    slug = f"add-{socket.replace('.', '-')}"
+    return Plug(
+        id=slug,
+        name="Plug here",
+        description="Showcase: add your extension plug on this socket.",
+        socket=socket,
+        href=f"/static/{slug}/index.js",
+    )

--- a/backend/swo_playground/routers/plugs/orders.py
+++ b/backend/swo_playground/routers/plugs/orders.py
@@ -1,0 +1,17 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+from swo_playground.routers.plugs.common import add_plug
+
+orders_router = PlugRouter()
+
+
+@orders_router.register()
+def order_plugs() -> list[Plug]:
+    """Declare the `add` showcase plugs for the order sockets."""
+    return [
+        add_plug("portal.commerce.orders.actions"),
+        add_plug("portal.commerce.orders.line.actions"),
+        add_plug("portal.commerce.orders.order"),
+        add_plug("portal.commerce.orders.order.actions"),
+    ]

--- a/backend/swo_playground/routers/plugs/portal.py
+++ b/backend/swo_playground/routers/plugs/portal.py
@@ -1,0 +1,28 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+from swo_playground.routers.plugs.common import add_plug
+
+portal_router = PlugRouter()
+
+
+@portal_router.register()
+def portal_plugs() -> list[Plug]:
+    """Declare top-level portal plugs: the examples app, the guide and the add showcase."""
+    return [
+        Plug(
+            id="examples",
+            name="Extension examples",
+            description="Learn more about the extensions UI SDK and its capabilities.",
+            socket="portal",
+            href="/static/examples/index.js",
+        ),
+        Plug(
+            id="guide",
+            name="Extension guide",
+            description="Read about the essential basics of extensions development.",
+            socket="portal",
+            href="/static/guide/index.js",
+        ),
+        add_plug("portal"),
+    ]

--- a/backend/swo_playground/routers/plugs/subscriptions.py
+++ b/backend/swo_playground/routers/plugs/subscriptions.py
@@ -1,0 +1,17 @@
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+from swo_playground.routers.plugs.common import add_plug
+
+subscriptions_router = PlugRouter()
+
+
+@subscriptions_router.register()
+def subscription_plugs() -> list[Plug]:
+    """Declare the `add` showcase plugs for the subscription sockets."""
+    return [
+        add_plug("portal.commerce.subscriptions.actions"),
+        add_plug("portal.commerce.subscriptions.line.actions"),
+        add_plug("portal.commerce.subscriptions.subscription"),
+        add_plug("portal.commerce.subscriptions.subscription.actions"),
+    ]

--- a/backend/tests/routers/test_showcase_plugs.py
+++ b/backend/tests/routers/test_showcase_plugs.py
@@ -1,0 +1,46 @@
+from swo_playground.app import ext_app
+from swo_playground.routers.plugs.common import add_plug
+
+# Sockets served by the per-socket `add` showcase, registered across the
+# per-entity plug routers (portal / orders / subscriptions / agreements /
+# assets / accounts).
+ADD_SOCKETS = (
+    "portal",
+    "portal.commerce.orders.actions",
+    "portal.commerce.orders.line.actions",
+    "portal.commerce.orders.order",
+    "portal.commerce.orders.order.actions",
+    "portal.commerce.subscriptions.actions",
+    "portal.commerce.subscriptions.line.actions",
+    "portal.commerce.subscriptions.subscription",
+    "portal.commerce.subscriptions.subscription.actions",
+    "portal.commerce.agreements.actions",
+    "portal.commerce.assets.actions",
+    "portal.commerce.assets.line.actions",
+    "portal.commerce.assets.asset",
+    "portal.commerce.assets.asset.actions",
+    "portal.accounts.sellers.seller.actions",
+)
+
+
+def _socket_href(plug) -> tuple[str, str]:
+    return plug.socket, plug.href
+
+
+def test_portal_showcase_plugs_registered():
+    result = {plug.id: plug.model_dump() for plug in ext_app.to_meta_config().plugs}
+
+    assert result["examples"]["socket"] == "portal"
+    assert result["examples"]["href"] == "/static/examples/index.js"
+    assert result["guide"]["socket"] == "portal"
+    assert result["guide"]["href"] == "/static/guide/index.js"
+
+
+def test_add_showcase_plugs_registered():
+    expected = {plug.id: _socket_href(plug) for plug in map(add_plug, ADD_SOCKETS)}
+    registered = ext_app.to_meta_config().plugs
+    add_plugs = [plug for plug in registered if plug.id.startswith("add-")]
+
+    result = {plug.id: _socket_href(plug) for plug in add_plugs}
+
+    assert result == expected

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ The extension currently registers:
 - agreement API routes under `/api/v2/agreements`
 - order event route `/events/v2/orders/purchase`
 - agreement event route `/events/v2/agreements/complete`
-- agreement-related Marketplace Portal plugs that load bundles from `/static/`
+- Marketplace Portal plugs that load bundles from `/static/`: the agreement plugs plus a UI SDK showcase (an examples app, a guide, and per-socket "add a plug" demos)
 
 ## Data Flow
 
@@ -47,9 +47,16 @@ The frontend follows a small set of conventions:
   discovers these entry points by convention and emits one IIFE bundle per module
   into `static/<name>/index.js`. The bundle filename must match the `href` in the
   plug metadata, or MPT cannot load the iframe.
+- **Many similar plugs**: when the same UI must cover many sockets (the
+  `add-<socket>` showcase), each socket keeps its own thin module directory that
+  mounts a shared component with the socket passed as a prop. This stays within
+  the one-module-per-plug convention — there is deliberately no build-time
+  fan-out from a single source and no separate socket manifest, so a socket is
+  added or removed as one module directory plus one plug registration.
 - **Shared layer**: `frontend/src/shared/` holds reusable building blocks —
-  `components/` (presentational UI), `hooks/` (for example `useAgreement`, which
-  fetches `/api/v2/agreements/{id}` through the SDK `http` client and exposes
+  `components/` (presentational UI, including `AddPlugShowcase` reused by the
+  `add-*` modules), `hooks/` (for example `useAgreement`, which fetches
+  `/api/v2/agreements/{id}` through the SDK `http` client and exposes
   load/error/ready states), and `model.ts` (response types and formatters).
 - **Build output**: the build emits bundles plus sourcemaps, and TypeScript
   declarations under `static/types/`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -25,7 +25,9 @@ sync) — so you can exercise the playground without writing requests by hand.
 - `events_orders_router` — order event handling
 - `events_agreements_router` — agreement event handling
 - `api_agreements_router` — agreement API endpoints
-- `plug_agreements_router` — Marketplace Portal plugs
+- `plug_portal_router` — top-level portal plugs (examples app, guide, `add` showcase)
+- `plug_agreements_router` — agreement plugs (the real examples plus the agreements `add` showcase)
+- `plug_orders_router` / `plug_subscriptions_router` / `plug_assets_router` / `plug_accounts_router` — per-entity `add` showcase plugs
 
 Each router below is an independent example and can be read on its own.
 
@@ -108,6 +110,36 @@ Each module's `index.tsx` follows the same entry-point pattern: import the
 `useAgreementId`, `AgreementDetailsList`, `model.ts`) live under
 [`frontend/src/shared/`](../frontend/src/shared/); see
 [docs/architecture.md](architecture.md#frontend) for the frontend structure.
+
+## UI SDK Showcase Plugs
+
+These plugs demonstrate the UI SDK breadth rather than a specific business flow.
+Like the agreement plugs, they are organised **per entity** — one `PlugRouter`
+file each: [`portal.py`](../backend/swo_playground/routers/plugs/portal.py)
+(top-level: examples, guide, `add`), [`orders.py`](../backend/swo_playground/routers/plugs/orders.py),
+[`subscriptions.py`](../backend/swo_playground/routers/plugs/subscriptions.py),
+[`assets.py`](../backend/swo_playground/routers/plugs/assets.py),
+[`accounts.py`](../backend/swo_playground/routers/plugs/accounts.py), and the
+agreements `add` plug in [`agreements.py`](../backend/swo_playground/routers/plugs/agreements.py):
+
+| Plug id / socket | Frontend module | Demonstrates |
+| --- | --- | --- |
+| `examples` — `portal` | [`modules/examples/`](../frontend/src/modules/examples/) | A multi-tab React app (`react-router`) touring the UI SDK: Introduction, Basics, Context (`useMPTContext`), API calls (the `http` client feeding a server-driven `Grid` via `useGridWithRql` + RQL), and UI elements (buttons, inputs, selects, toggles, date pickers, grids, entity references) |
+| `guide` — `portal` | [`modules/guide/`](../frontend/src/modules/guide/) | Rendering bundled Markdown with `InlineMarkdown` (esbuild `.md` text loader) |
+| `add-<socket>` (one per socket) | [`modules/add-*/`](../frontend/src/modules/) | A "plug here" scaffold shown on every remaining Portal socket, so the full set of sockets is covered |
+
+The `add-*` plugs cover many near-identical sockets without duplicating logic:
+each is a thin module directory whose `index.tsx` mounts the shared
+[`AddPlugShowcase`](../frontend/src/shared/components/AddPlugShowcase.tsx)
+component with its socket passed as a prop. There is no build-time socket
+injection or shared socket manifest — one socket is one module directory plus
+one `add_plug(...)` line in the matching per-entity router (the helper lives in
+[`plugs/common.py`](../backend/swo_playground/routers/plugs/common.py); see
+[docs/architecture.md](architecture.md#frontend)).
+
+A socket-less modal round-trip demo (a dialog/wizard opened purely via
+`useMPTModal().open()`) is intentionally not included yet: the backend `Plug`
+requires a `socket`, so it awaits a dedicated modal plug type in the SDK.
 
 ## Migrations
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,12 @@
       "dependencies": {
         "@mpt-extension/sdk": "^0.0.7",
         "@mpt-extension/sdk-react": "^0.0.7",
+        "@softwareone-platform/rql-client": "^0.1.1",
         "@softwareone-platform/sdk-react-ui-v0": "^0.0.2",
         "esbuild-sass-plugin": "^3.6.0",
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "react-router": "^7.13.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4275,7 +4277,6 @@
       "resolved": "https://registry.npmjs.org/@softwareone-platform/rql-client/-/rql-client-0.1.1.tgz",
       "integrity": "sha512-ghv1gHiC/pSrxrWwa/UMmz8WCCcdRqNR8voSeHU6F02LNSgu+o7eqn1JGGVANJQtONnT91s6QcqVFk56PYqwwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6175,7 +6176,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11878,7 +11878,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
       "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -12585,8 +12584,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,10 +20,12 @@
   "dependencies": {
     "@mpt-extension/sdk": "^0.0.7",
     "@mpt-extension/sdk-react": "^0.0.7",
+    "@softwareone-platform/rql-client": "^0.1.1",
     "@softwareone-platform/sdk-react-ui-v0": "^0.0.2",
     "esbuild-sass-plugin": "^3.6.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,1 +1,6 @@
 declare module '*.scss';
+
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/frontend/src/modules/add-portal-accounts-sellers-seller-actions/index.tsx
+++ b/frontend/src/modules/add-portal-accounts-sellers-seller-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.accounts.sellers.seller.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-agreements-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-agreements-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.agreements.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-assets-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-assets-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.assets.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-assets-asset-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-assets-asset-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.assets.asset.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-assets-asset/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-assets-asset/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.assets.asset" />);
+});

--- a/frontend/src/modules/add-portal-commerce-assets-line-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-assets-line-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.assets.line.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-orders-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-orders-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.orders.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-orders-line-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-orders-line-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.orders.line.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-orders-order-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-orders-order-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.orders.order.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-orders-order/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-orders-order/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.orders.order" />);
+});

--- a/frontend/src/modules/add-portal-commerce-subscriptions-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-subscriptions-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.subscriptions.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-subscriptions-line-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-subscriptions-line-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.subscriptions.line.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-subscriptions-subscription-actions/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-subscriptions-subscription-actions/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.subscriptions.subscription.actions" />);
+});

--- a/frontend/src/modules/add-portal-commerce-subscriptions-subscription/index.tsx
+++ b/frontend/src/modules/add-portal-commerce-subscriptions-subscription/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal.commerce.subscriptions.subscription" />);
+});

--- a/frontend/src/modules/add-portal/index.tsx
+++ b/frontend/src/modules/add-portal/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import { AddPlugShowcase } from '../../shared/components/AddPlugShowcase';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<AddPlugShowcase socket="portal" />);
+});

--- a/frontend/src/modules/examples/App.tsx
+++ b/frontend/src/modules/examples/App.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import { Route, Routes, useNavigate, useParams } from 'react-router';
+
+import { Tab, Tabs } from '@softwareone-platform/sdk-react-ui-v0/tabs';
+import { DesignSystemOptionsProvider } from '@softwareone-platform/sdk-react-ui-v0/utils';
+
+import { Api } from './views/Api';
+import { Basics } from './views/Basics';
+import { Context } from './views/Context';
+import { Elements } from './views/Elements';
+import { Intro } from './views/Intro';
+
+function View() {
+  const { tab } = useParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!tab) {
+      // replace so the bare "/" entry doesn't trap back navigation
+      navigate('/intro', { replace: true });
+    }
+  }, [tab, navigate]);
+
+  if (!tab) {
+    return null;
+  }
+
+  return (
+    <DesignSystemOptionsProvider
+      value={{
+        dateFormat: 'dd MMM yyyy',
+        inputDateFormat: 'P',
+        languageCode: 'en-GB',
+        timeFormat: 'HH:mm',
+      }}
+    >
+      <Tabs selectedTabId={tab} onTabChange={(id) => navigate(`/${id}`)}>
+        <Tab id="intro" title="Introduction">
+          <Tab.Content>
+            <Intro />
+          </Tab.Content>
+        </Tab>
+        <Tab id="basics" title="Basics">
+          <Tab.Content>
+            <Basics />
+          </Tab.Content>
+        </Tab>
+        <Tab id="elements" title="UI elements">
+          <Tab.Content>
+            <Elements />
+          </Tab.Content>
+        </Tab>
+        <Tab id="context" title="Context">
+          <Tab.Content>
+            <Context />
+          </Tab.Content>
+        </Tab>
+        <Tab id="api" title="API calls">
+          <Tab.Content>
+            <Api />
+          </Tab.Content>
+        </Tab>
+      </Tabs>
+    </DesignSystemOptionsProvider>
+  );
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/:tab" element={<View />} />
+      <Route path="/" element={<View />} />
+    </Routes>
+  );
+}

--- a/frontend/src/modules/examples/index.tsx
+++ b/frontend/src/modules/examples/index.tsx
@@ -1,0 +1,18 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
+
+import App from './App';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
+});

--- a/frontend/src/modules/examples/views/Api.tsx
+++ b/frontend/src/modules/examples/views/Api.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useMemo } from 'react';
+
+import { http } from '@mpt-extension/sdk';
+import { RqlQuery } from '@softwareone-platform/rql-client';
+import { Card } from '@softwareone-platform/sdk-react-ui-v0/card';
+import {
+  CallApiParams,
+  Grid,
+  GridCellSimple,
+  GridCellStatus,
+  GridColumnDefinition,
+  useGridWithRql,
+} from '@softwareone-platform/sdk-react-ui-v0/grid';
+
+import { ShowCode } from './elements/ShowCode';
+
+const code = `
+import { http } from '@mpt-extension/sdk';
+
+// http is a pre-configured axios instance.
+// It manages JWT tokens automatically — before each request it checks
+// whether the current token is still valid and refreshes it if needed.
+// Use it exactly like axios.
+
+// Call the Marketplace API directly
+const { data } = await http.get(
+  '/public/v1/commerce/subscriptions',
+  { params: { limit: 100, offset: 0 } },
+);
+const subscriptions = data.data; // array of subscription objects
+
+// Or call your own extension backend
+const agreement = await http.get('/api/v2/agreements/AGR-1234');
+`;
+
+interface Subscription {
+  id: string;
+  status: string;
+  name: string;
+  product: { id: string; name: string };
+}
+
+const STATUS_MAP: Record<string, 'success' | 'error' | 'info' | 'inactive'> = {
+  Active: 'success',
+  Terminated: 'error',
+  Terminating: 'inactive',
+  Updating: 'info',
+};
+
+const columns: GridColumnDefinition<Subscription>[] = [
+  {
+    name: 'id',
+    title: 'ID',
+    initialWidth: 180,
+    cell: (item) => <GridCellSimple>{item.id}</GridCellSimple>,
+  },
+  {
+    name: 'name',
+    title: 'Name',
+    initialWidth: 240,
+    cell: (item) => <GridCellSimple>{item.name}</GridCellSimple>,
+  },
+  {
+    name: 'product',
+    title: 'Product',
+    initialWidth: 240,
+    cell: (item) => <GridCellSimple>{item.product?.name ?? '—'}</GridCellSimple>,
+  },
+  {
+    name: 'status',
+    title: 'Status',
+    initialWidth: 140,
+    cell: (item) => <GridCellStatus status={STATUS_MAP[item.status] ?? 'inactive'} label={item.status} />,
+  },
+];
+
+export function Api() {
+  const gridConfig = useMemo(
+    () => ({
+      id: 'api-subscriptions-grid',
+      columns,
+      paging: { page: 1, pageSize: 10, total: 0 },
+      isToHideToolbar: true,
+    }),
+    [],
+  );
+
+  const callApi = useCallback(async (query: RqlQuery<Subscription>, { controller }: CallApiParams) => {
+    const { data } = await http.get(`/public/v1/commerce/subscriptions?${query.toString()}`, {
+      signal: controller.signal,
+    });
+    return {
+      data: data.data as Subscription[],
+      total: data.$meta.pagination.total as number,
+    };
+  }, []);
+
+  const gridProps = useGridWithRql(gridConfig, callApi);
+
+  return (
+    <>
+      <h2>API calls</h2>
+      <p>
+        The SDK provides <code>http</code>, a pre-configured axios instance that manages JWT
+        authentication automatically. Before each request it checks whether the token is still valid
+        (with a 60-second buffer) and transparently refreshes it when needed. Use it exactly like axios
+        — no manual token handling required.
+      </p>
+      <p>
+        All platform APIs are proxied through the extension domain, so you can call them using relative
+        paths like <code>/public/v1/...</code> — there is no need to specify the full platform
+        hostname.
+      </p>
+
+      <h3>Live: subscriptions from the Marketplace API</h3>
+      <p>
+        The grid below is populated by a real <code>GET /public/v1/commerce/subscriptions</code> call
+        made with <code>http</code> from the SDK. Pagination, sorting, and filtering are handled
+        server-side via RQL queries.
+      </p>
+
+      <Card>
+        <Grid {...gridProps} />
+      </Card>
+
+      <h3>Usage</h3>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/Basics.tsx
+++ b/frontend/src/modules/examples/views/Basics.tsx
@@ -1,0 +1,48 @@
+export function Basics() {
+  return (
+    <>
+      <h1>Here come the basics</h1>
+      <p>Setting up an Extension UI takes two steps. First, install the SDK:</p>
+      <pre>
+        <code>npm i @mpt-extension/sdk</code>
+      </pre>
+      <p>
+        Then, in your module&apos;s entry point, call <code>setup()</code> with a callback that mounts
+        your React app into the provided root element. The platform invokes the callback once the
+        iframe is ready and the root node is attached to the DOM:
+      </p>
+      <pre>
+        <code>{`
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+  root.render(<App/>);
+});
+`}</code>
+      </pre>
+      <p>
+        That is all the wiring required — from here you can use the SDK hooks to read context, emit
+        events, call APIs, and open modals.
+      </p>
+
+      <h2>Routing</h2>
+      <p>
+        Extension UI routing is synchronised with the platform&apos;s URL. The platform&apos;s current
+        page path is suffixed with <code>/-/</code> followed by the extension&apos;s own internal path.
+        So if the platform page lives at <code>/foo</code> and your extension defines a route{' '}
+        <code>/bar</code>, the address bar shows <code>/foo/-/bar</code>. Following such a URL as a
+        link delivers the inner path (<code>/bar</code>) to the Extension UI, and the SDK keeps the
+        two halves in sync as the user navigates inside your app.
+      </p>
+      <p>
+        In practice you just use <code>react-router</code> as you normally would — declare your
+        routes, call <code>useNavigate()</code>, read <code>useParams()</code>. This very page is a
+        working example: each tab is bound to a route segment and clicking a tab triggers a{' '}
+        <code>navigate()</code> call, which is reflected in the platform URL.
+      </p>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/Context.tsx
+++ b/frontend/src/modules/examples/views/Context.tsx
@@ -1,0 +1,90 @@
+import { useMPTContext } from '@mpt-extension/sdk-react';
+
+import { ShowCode } from './elements/ShowCode';
+
+const codeBasic = `
+import { useMPTContext } from '@mpt-extension/sdk-react';
+
+// The shape of the context depends on where your Plug is rendered.
+// auth is always present; data carries socket-specific objects.
+
+interface MPTContext {
+  auth: {
+    user:    { id: string };
+    account: { id: string; type: string };
+  };
+  data: object; // <-- depends on the socket (see below)
+}
+
+function MyComponent() {
+  const ctx = useMPTContext<MPTContext>();
+
+  // auth is always available
+  const userId    = ctx.auth.user.id;
+  const accountId = ctx.auth.account.id;
+
+  // The contents of data depend on the socket where your Plug is rendered.
+  // For example, a Plug on a subscription detail page receives the
+  // subscription object; on an order page it would be the order, and so on.
+  // Top-level pages have no entity in scope, so data is empty.
+  const subscription = ctx.data.subscription;
+
+  return <p>Subscription {subscription.id} — {subscription.status}</p>;
+}
+`;
+
+const codeReactive = `
+// The context updates automatically when the platform pushes changes.
+// Your component re-renders with fresh data — no polling required.
+
+function OrderSidebar() {
+  const { auth, data } = useMPTContext();
+  const order = data.order; // available on portal.commerce.orders.order
+
+  return (
+    <div>
+      <p>Order: {order.id}</p>
+      <p>Status: {order.status}</p>
+      <p>Viewed by: {auth.user.id}</p>
+    </div>
+  );
+}
+`;
+
+export function Context() {
+  const ctx = useMPTContext();
+
+  return (
+    <>
+      <h2>Platform context</h2>
+      <p>
+        Every Plug receives context from the platform via <code>useMPTContext()</code>. The context
+        always contains <code>auth</code> with the current user and account. The <code>data</code>{' '}
+        field carries objects relevant to the socket where the Plug is rendered — for example, the
+        current order, subscription, or agreement.
+      </p>
+      <p>
+        This Plug is mounted at a top-level socket (<code>portal</code>), so <code>data</code> is
+        empty here. When your Plug targets a detail page like{' '}
+        <code>portal.commerce.orders.order</code>, the platform will populate <code>data</code> with
+        the entity in scope.
+      </p>
+
+      <h3>Live context</h3>
+      <p>This is the actual context object received by this page right now:</p>
+      <pre>
+        <code>{JSON.stringify(ctx, null, 2)}</code>
+      </pre>
+
+      <h3>Usage</h3>
+      <ShowCode>{codeBasic}</ShowCode>
+
+      <h3>Reactive updates</h3>
+      <p>
+        The context updates automatically when the platform pushes changes — your component re-renders
+        with fresh data, no polling needed.
+      </p>
+      <ShowCode>{codeReactive}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/Elements.scss
+++ b/frontend/src/modules/examples/views/Elements.scss
@@ -1,0 +1,3 @@
+.elements-narrow {
+  max-width: 820px;
+}

--- a/frontend/src/modules/examples/views/Elements.tsx
+++ b/frontend/src/modules/examples/views/Elements.tsx
@@ -1,0 +1,49 @@
+import { Divider } from '@softwareone-platform/sdk-react-ui-v0/divider';
+
+import { ButtonExample } from './elements/ButtonExample';
+import { CheckboxExample } from './elements/CheckboxExample';
+import { DatePickerExample } from './elements/DatePickerExample';
+import { EntityReferenceExample } from './elements/EntityReferenceExample';
+import { GridExample } from './elements/GridExample';
+import { InputExample } from './elements/InputExample';
+import { SelectExample } from './elements/SelectExample';
+import { ToggleExample } from './elements/ToggleExample';
+
+import './Elements.scss';
+
+export function Elements() {
+  return (
+    <>
+      <div className="elements-narrow">
+        <h2>Basic UI elements</h2>
+        <p>
+          Below are a few key examples of the basic UI elements you will most often reach for when
+          building an extension.
+        </p>
+        <Divider />
+        <ButtonExample />
+        <Divider />
+        <h2>Form elements</h2>
+        <p>
+          Form controls follow a predictable pattern: a controlled <code>value</code> plus an{' '}
+          <code>onChange</code> callback. Labels, descriptions, and error messages are rendered by the
+          component itself — you rarely need to wrap them in your own layout.
+        </p>
+        <Divider />
+        <InputExample />
+        <Divider />
+        <SelectExample />
+        <Divider />
+        <CheckboxExample />
+        <Divider />
+        <ToggleExample />
+        <Divider />
+        <DatePickerExample />
+        <Divider />
+        <EntityReferenceExample />
+      </div>
+      <Divider />
+      <GridExample />
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/Intro.tsx
+++ b/frontend/src/modules/examples/views/Intro.tsx
@@ -1,0 +1,25 @@
+export function Intro() {
+  return (
+    <>
+      <h1>Greetings to all extension developers!</h1>
+
+      <p>
+        Assuming you already created an Extension in the platform UI and you have its backend up and
+        running based on this playground application or a solution of your own, your next step would
+        be to create an actual UI for your extension.
+      </p>
+
+      <p>
+        We try to keep it as simple as possible and leave more space for your own creativity, while
+        providing you with essential tools that, we hope, make your development experience smooth and
+        controllable.
+      </p>
+
+      <p>
+        This short showcase introduces some basic use cases and recipes — including Extensions SDK
+        tools usage and some basic UI elements that will help to align the UX of your extension with
+        the Marketplace platform.
+      </p>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/ButtonExample.scss
+++ b/frontend/src/modules/examples/views/elements/ButtonExample.scss
@@ -1,0 +1,5 @@
+.button-row {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}

--- a/frontend/src/modules/examples/views/elements/ButtonExample.tsx
+++ b/frontend/src/modules/examples/views/elements/ButtonExample.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+import { Button } from '@softwareone-platform/sdk-react-ui-v0/button';
+
+import { ShowCode } from './ShowCode';
+
+import './ButtonExample.scss';
+
+const code = `
+<Button type="primary" onClick={() => setLastClicked('Save')}>Save</Button>
+<Button type="secondary" onClick={() => setLastClicked('Cancel')}>Cancel</Button>
+<Button type="outline" onClick={() => setLastClicked('Edit')}>Edit</Button>
+<Button type="text" onClick={() => setLastClicked('More info')}>More info</Button>
+<Button type="primary" color="danger" onClick={() => setLastClicked('Delete')}>Delete</Button>
+<Button type="primary" isBusy>Saving…</Button>
+<Button isDisabled>Disabled</Button>
+`;
+
+export function ButtonExample() {
+  const [lastClicked, setLastClicked] = useState<string | null>(null);
+
+  return (
+    <>
+      <h2>Buttons</h2>
+      <p>
+        Use the <code>type</code> prop to pick a visual variant (<code>primary</code>,{' '}
+        <code>secondary</code>, <code>outline</code>, <code>text</code>) and <code>color</code> for
+        intent (<code>primary</code>, <code>danger</code>, <code>dark</code>). Toggle{' '}
+        <code>isBusy</code> for loading state.
+      </p>
+      <div className="button-row">
+        <Button type="primary" onClick={() => setLastClicked('Save')}>
+          Save
+        </Button>
+        <Button type="secondary" onClick={() => setLastClicked('Cancel')}>
+          Cancel
+        </Button>
+        <Button type="outline" onClick={() => setLastClicked('Edit')}>
+          Edit
+        </Button>
+        <Button type="text" onClick={() => setLastClicked('More info')}>
+          More info
+        </Button>
+        <Button type="primary" color="danger" onClick={() => setLastClicked('Delete')}>
+          Delete
+        </Button>
+        <Button type="primary" isBusy>
+          Saving…
+        </Button>
+        <Button isDisabled>Disabled</Button>
+      </div>
+      <p>
+        Last clicked: <code>{lastClicked ?? '—'}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/CheckboxExample.tsx
+++ b/frontend/src/modules/examples/views/elements/CheckboxExample.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import { Checkbox } from '@softwareone-platform/sdk-react-ui-v0/checkbox';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+const [isSubscribed, setIsSubscribed] = useState(false);
+
+<Checkbox
+  id="subscribe"
+  label="Subscribe to product updates"
+  isChecked={isSubscribed}
+  onChange={(e) => setIsSubscribed(e.target.checked)}
+/>
+`;
+
+export function CheckboxExample() {
+  const [isSubscribed, setIsSubscribed] = useState(false);
+
+  return (
+    <>
+      <h3>Checkbox</h3>
+      <Checkbox
+        id="subscribe"
+        label="Subscribe to product updates"
+        isChecked={isSubscribed}
+        onChange={(e) => setIsSubscribed(e.target.checked)}
+      />
+      <p>
+        Current value: <code>{String(isSubscribed)}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/DatePickerExample.tsx
+++ b/frontend/src/modules/examples/views/elements/DatePickerExample.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+import { DatePicker } from '@softwareone-platform/sdk-react-ui-v0/date-picker';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+const [date, setDate] = useState<string>('2026-04-13');
+
+<DatePicker
+  label="Start date"
+  value={date}
+  onChange={(value) => setDate(value as string)}
+  dateFormat="yyyy-MM-dd"
+  placeholder="yyyy-MM-dd"
+/>
+`;
+
+export function DatePickerExample() {
+  const [date, setDate] = useState<string>('2026-04-13');
+
+  return (
+    <>
+      <h3>Date picker</h3>
+      <DatePicker
+        label="Start date"
+        value={date}
+        onChange={(value) => setDate(value as string)}
+        dateFormat="yyyy-MM-dd"
+        placeholder="yyyy-MM-dd"
+      />
+      <p>
+        Current value: <code>{date}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/EntityReferenceExample.tsx
+++ b/frontend/src/modules/examples/views/elements/EntityReferenceExample.tsx
@@ -1,0 +1,38 @@
+import { Avatar } from '@softwareone-platform/sdk-react-ui-v0/avatar';
+import { EntityReference } from '@softwareone-platform/sdk-react-ui-v0/entity-reference';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+<EntityReference
+  icon={<Avatar size={40} shape="circle" type="text" text="Ada Lovelace" bgColor="var(--brand-primary)"/>}
+  primaryContent="Ada Lovelace"
+  secondaryContent="USR-1234-5678"
+  chipLabel="Active"
+  chipColor="success"
+  isPrimaryContentBold
+/>
+`;
+
+export function EntityReferenceExample() {
+  return (
+    <>
+      <h2>Entity reference</h2>
+      <p>
+        <code>EntityReference</code> is the canonical way to render a reference to a platform entity —
+        a user, an account, a product — with an avatar, a primary label, a secondary identifier, and
+        optionally a status chip. Use it in lists, grid cells, and detail headers to stay consistent
+        with the rest of the platform.
+      </p>
+      <EntityReference
+        icon={<Avatar size={40} shape="circle" type="text" text="Ada Lovelace" bgColor="var(--brand-primary)" />}
+        primaryContent="Ada Lovelace"
+        secondaryContent="USR-1234-5678"
+        chipLabel="Active"
+        chipColor="success"
+        isPrimaryContentBold
+      />
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/GridExample.tsx
+++ b/frontend/src/modules/examples/views/elements/GridExample.tsx
@@ -1,0 +1,106 @@
+import { Card } from '@softwareone-platform/sdk-react-ui-v0/card';
+import {
+  Grid,
+  GridCellSimple,
+  GridColumnDefinition,
+  useGridInMemory,
+} from '@softwareone-platform/sdk-react-ui-v0/grid';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+interface Person {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+const people: Person[] = [
+  { id: '1', name: 'Ada Lovelace', email: 'ada@example.com', role: 'Admin' },
+  { id: '2', name: 'Alan Turing', email: 'alan@example.com', role: 'Developer' },
+  { id: '3', name: 'Grace Hopper', email: 'grace@example.com', role: 'Developer' },
+];
+
+const peopleColumns: GridColumnDefinition<Person>[] = [
+  { name: 'name', title: 'Name', initialWidth: 200,
+    cell: (item) => <GridCellSimple>{item.name}</GridCellSimple> },
+  { name: 'email', title: 'Email', initialWidth: 260,
+    cell: (item) => <GridCellSimple>{item.email}</GridCellSimple> },
+  { name: 'role', title: 'Role', initialWidth: 140,
+    cell: (item) => <GridCellSimple>{item.role}</GridCellSimple> },
+];
+
+const peopleGridConfig = {
+  id: 'elements-people-grid',
+  columns: peopleColumns,
+  paging: { page: 1, pageSize: 10, total: people.length },
+};
+
+function PeopleGrid() {
+  const gridProps = useGridInMemory(people, peopleGridConfig);
+  return <Grid {...gridProps} />;
+}
+`;
+
+interface Person {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+const people: Person[] = [
+  { id: '1', name: 'Ada Lovelace', email: 'ada@example.com', role: 'Admin' },
+  { id: '2', name: 'Alan Turing', email: 'alan@example.com', role: 'Developer' },
+  { id: '3', name: 'Grace Hopper', email: 'grace@example.com', role: 'Developer' },
+];
+
+const peopleColumns: GridColumnDefinition<Person>[] = [
+  {
+    name: 'name',
+    title: 'Name',
+    initialWidth: 200,
+    cell: (item) => <GridCellSimple>{item.name}</GridCellSimple>,
+  },
+  {
+    name: 'email',
+    title: 'Email',
+    initialWidth: 260,
+    cell: (item) => <GridCellSimple>{item.email}</GridCellSimple>,
+  },
+  {
+    name: 'role',
+    title: 'Role',
+    initialWidth: 140,
+    cell: (item) => <GridCellSimple>{item.role}</GridCellSimple>,
+  },
+];
+
+const peopleGridConfig = {
+  id: 'elements-people-grid',
+  columns: peopleColumns,
+  paging: { page: 1, pageSize: 10, total: people.length },
+};
+
+export function GridExample() {
+  const gridProps = useGridInMemory(people, peopleGridConfig);
+
+  return (
+    <>
+      <h2>Grid</h2>
+      <p>
+        The <code>Grid</code> renders tabular data with sorting, filtering, pagination, and a toolbar
+        out of the box. For a small client-side dataset, feed it through <code>useGridInMemory</code>{' '}
+        and spread the result into <code>&lt;Grid/&gt;</code>. For server-driven data use{' '}
+        <code>useGridWithRql</code> or <code>useGridAsync</code>.
+      </p>
+
+      <Card>
+        <Grid {...gridProps} />
+      </Card>
+
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/InputExample.tsx
+++ b/frontend/src/modules/examples/views/elements/InputExample.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { Input } from '@softwareone-platform/sdk-react-ui-v0/input';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+const [value, setValue] = useState('');
+
+<Input
+  name="fullName"
+  label="Full name"
+  placeholder="Jane Doe"
+  value={value}
+  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+  description="Shown on your profile page"
+/>
+`;
+
+export function InputExample() {
+  const [value, setValue] = useState('');
+
+  return (
+    <>
+      <h3>Text input</h3>
+      <Input
+        name="fullName"
+        label="Full name"
+        placeholder="Jane Doe"
+        value={value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+        description="Shown on your profile page"
+      />
+      <p>
+        Current value: <code>{value || '—'}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/SelectExample.tsx
+++ b/frontend/src/modules/examples/views/elements/SelectExample.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { Select, SelectItem } from '@softwareone-platform/sdk-react-ui-v0/select';
+
+import { ShowCode } from './ShowCode';
+
+const roleOptions: SelectItem[] = [
+  { label: 'Administrator', value: 'admin' },
+  { label: 'Developer', value: 'developer' },
+  { label: 'Viewer', value: 'viewer' },
+];
+
+const code = `
+const roleOptions: SelectItem[] = [
+  { label: 'Administrator', value: 'admin' },
+  { label: 'Developer', value: 'developer' },
+  { label: 'Viewer', value: 'viewer' },
+];
+
+const [role, setRole] = useState<string>('developer');
+
+<Select
+  options={roleOptions}
+  value={role}
+  onChange={setRole}
+  controlLabel="Role"
+  placeholder="Pick a role"
+/>
+`;
+
+export function SelectExample() {
+  const [role, setRole] = useState<string>('developer');
+
+  return (
+    <>
+      <h3>Select</h3>
+      <Select
+        options={roleOptions}
+        value={role}
+        onChange={setRole}
+        controlLabel="Role"
+        placeholder="Pick a role"
+      />
+      <p>
+        Current value: <code>{role}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/ShowCode.scss
+++ b/frontend/src/modules/examples/views/elements/ShowCode.scss
@@ -1,0 +1,8 @@
+.show-code {
+  margin-top: var(--spacing-2);
+
+  &__toggle {
+    color: var(--brand-primary);
+    cursor: pointer;
+  }
+}

--- a/frontend/src/modules/examples/views/elements/ShowCode.tsx
+++ b/frontend/src/modules/examples/views/elements/ShowCode.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+import './ShowCode.scss';
+
+export function ShowCode({ children }: { children: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="show-code">
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((v) => !v);
+        }}
+        className="show-code__toggle"
+      >
+        {open ? 'Less' : 'More'}
+      </a>
+      {open && (
+        <pre>
+          <code>{children.trim()}</code>
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/modules/examples/views/elements/ToggleExample.tsx
+++ b/frontend/src/modules/examples/views/elements/ToggleExample.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { Toggle } from '@softwareone-platform/sdk-react-ui-v0/toggle';
+
+import { ShowCode } from './ShowCode';
+
+const code = `
+const [isEnabled, setIsEnabled] = useState(true);
+
+<Toggle
+  label="Enable notifications"
+  isChecked={isEnabled}
+  onChange={setIsEnabled}
+/>
+`;
+
+export function ToggleExample() {
+  const [isEnabled, setIsEnabled] = useState(true);
+
+  return (
+    <>
+      <h3>Toggle</h3>
+      <Toggle label="Enable notifications" isChecked={isEnabled} onChange={setIsEnabled} />
+      <p>
+        Current value: <code>{String(isEnabled)}</code>
+      </p>
+      <ShowCode>{code}</ShowCode>
+    </>
+  );
+}

--- a/frontend/src/modules/guide/App.tsx
+++ b/frontend/src/modules/guide/App.tsx
@@ -1,0 +1,21 @@
+import { Card } from '@softwareone-platform/sdk-react-ui-v0/card';
+import { InlineMarkdown } from '@softwareone-platform/sdk-react-ui-v0/markdown/inline';
+
+import text from './text.md';
+
+export default function App() {
+  return (
+    <Card>
+      <InlineMarkdown
+        value={text}
+        styleOverrides={{
+          h1: '__h1',
+          h2: '__h2',
+          h3: '__h3',
+          code: '__code',
+          pre: '__pre',
+        }}
+      />
+    </Card>
+  );
+}

--- a/frontend/src/modules/guide/index.tsx
+++ b/frontend/src/modules/guide/index.tsx
@@ -1,0 +1,13 @@
+import '../../fixes/safe-storage';
+
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+import '../../style.scss';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+
+  root.render(<App />);
+});

--- a/frontend/src/modules/guide/text.md
+++ b/frontend/src/modules/guide/text.md
@@ -1,0 +1,73 @@
+# Building Extensions for the SoftwareONE Marketplace
+
+## What Is an Extension?
+
+An Extension is a third-party web application whose UI plugs into the SoftwareONE Marketplace
+platform. Each Extension can contribute one or more **Plugs** — independent UI pieces, each targeting
+a named **Socket** (a predefined place in the platform UI, such as an order detail tab or a top-level
+navigation section). A Plug is a JavaScript bundle that the platform loads into an iframe when the
+corresponding Socket is rendered.
+
+The three terms to remember: **Extension** is your app, **Socket** is where it appears, **Plug** is
+what you ship to fill that socket.
+
+## Extension Structure
+
+A typical extension has two parts:
+
+- **Frontend** — React/TypeScript UI, organised as one module per Plug, each built into its own JS
+  bundle under `/static`.
+- **Backend** — Python/FastAPI service handling platform events, validation webhooks, background
+  tasks, scheduled jobs, and custom API endpoints.
+
+## Declaring Plugs
+
+Unlike a `meta.yaml`-based extension, this playground declares its Plugs **in Python** using a
+`PlugRouter`. Each `Plug` maps a socket to the static bundle that fills it:
+
+```python
+from mpt_extension_sdk.routing import PlugRouter
+from mpt_extension_sdk.routing.plugs import Plug
+
+showcase_router = PlugRouter()
+
+@showcase_router.register()
+def showcase_plugs() -> list[Plug]:
+    return [
+        Plug(
+            id="examples",
+            name="Extension examples",
+            description="SDK UI capabilities showcase.",
+            socket="portal",
+            href="/static/examples/index.js",
+        ),
+    ]
+```
+
+The router is then mounted on the extension app with `ext_app.include_router(showcase_router)`.
+
+## Building the Frontend
+
+Each directory under `frontend/src/modules` is an entry point. `esbuild` bundles every
+`<module>/index.tsx` into `/static/<module>/index.js`. In your entry point you call `setup()` from the
+SDK and mount your React app into the provided root element:
+
+```tsx
+import { setup } from '@mpt-extension/sdk';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+setup((element: Element) => {
+  const root = createRoot(element);
+  root.render(<App/>);
+});
+```
+
+## What to Explore Next
+
+- **UI elements** — buttons, inputs, selects, toggles, date pickers, grids and entity references from
+  `@softwareone-platform/sdk-react-ui-v0`.
+- **Context** — read the current user, account, and the entity in scope with `useMPTContext()`.
+- **API calls** — call the Marketplace API or your own backend with the auto-authenticated `http`
+  client.
+- **Modals** — open dialogs and wizards with `useMPTModal()` and pass results back to the opener.

--- a/frontend/src/shared/components/AddPlugShowcase.scss
+++ b/frontend/src/shared/components/AddPlugShowcase.scss
@@ -1,0 +1,26 @@
+.add-plug {
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+  }
+
+  &__output {
+    position: relative;
+  }
+
+  &__context {
+    summary {
+      cursor: pointer;
+      user-select: none;
+      padding: var(--spacing-1) 0;
+    }
+
+    pre {
+      margin: var(--spacing-1) 0 0;
+      max-height: 240px;
+      overflow: auto;
+      font-size: 12px;
+    }
+  }
+}

--- a/frontend/src/shared/components/AddPlugShowcase.test.tsx
+++ b/frontend/src/shared/components/AddPlugShowcase.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { AddPlugShowcase } from './AddPlugShowcase';
+
+jest.mock(
+  '@mpt-extension/sdk-react',
+  () => ({
+    useMPTContext: jest.fn(() => ({})),
+    useMPTModal: jest.fn(() => ({ close: jest.fn(), open: jest.fn() })),
+  }),
+  { virtual: true },
+);
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/button', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    Button: ({ children }: { children?: import('react').ReactNode }) =>
+      React.createElement('button', null, children),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/card', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    Card: ({ children }: { children?: import('react').ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'card' }, children),
+  };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/divider', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return { Divider: () => React.createElement('hr', null) };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/input', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return { Input: ({ label }: { label?: string }) => React.createElement('label', null, label) };
+});
+
+jest.mock('@softwareone-platform/sdk-react-ui-v0/switcher', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return { Switcher: () => React.createElement('div', null) };
+});
+
+describe('AddPlugShowcase', () => {
+  it('renders a modal dialog header on an .actions socket', () => {
+    render(<AddPlugShowcase socket="portal.commerce.orders.order.actions" />);
+
+    expect(
+      screen.getByText('Add a Plug to portal.commerce.orders.order.actions'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('renders inside a card on the top-level portal socket', () => {
+    render(<AddPlugShowcase socket="portal" />);
+
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+    expect(screen.queryByText(/Add a Plug to/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/AddPlugShowcase.tsx
+++ b/frontend/src/shared/components/AddPlugShowcase.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+
+import { useMPTContext, useMPTModal } from '@mpt-extension/sdk-react';
+import { Button } from '@softwareone-platform/sdk-react-ui-v0/button';
+import { Card } from '@softwareone-platform/sdk-react-ui-v0/card';
+import { Divider } from '@softwareone-platform/sdk-react-ui-v0/divider';
+import { Input } from '@softwareone-platform/sdk-react-ui-v0/input';
+import { Switcher } from '@softwareone-platform/sdk-react-ui-v0/switcher';
+
+import './AddPlugShowcase.scss';
+
+type Format = 'yaml' | 'json';
+
+const formatOptions = [
+  { value: 'yaml', label: 'YAML' },
+  { value: 'json', label: 'JSON' },
+];
+
+interface PlugConfig {
+  id: string;
+  name: string;
+  description: string;
+  href: string;
+  condition: string;
+}
+
+function toYaml(plug: PlugConfig, socket: string): string {
+  const lines = [`- id: ${plug.id}`, `  socket: ${socket}`];
+  if (plug.name) lines.push(`  name: ${plug.name}`);
+  if (plug.description) lines.push(`  description: ${plug.description}`);
+  if (plug.href) lines.push(`  href: ${plug.href}`);
+  if (plug.condition) lines.push(`  condition: "${plug.condition}"`);
+  return lines.join('\n');
+}
+
+function toJson(plug: PlugConfig, socket: string): string {
+  const obj: Record<string, string> = { id: plug.id, socket };
+  if (plug.name) obj.name = plug.name;
+  if (plug.description) obj.description = plug.description;
+  if (plug.href) obj.href = plug.href;
+  if (plug.condition) obj.condition = plug.condition;
+  return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * SDK UI showcase: a "plug here" form whose target socket is supplied by the
+ * per-socket module that mounts it. Each socket has its own thin module entry
+ * (src/modules/add-*), so no build-time socket injection or shared socket
+ * manifest is needed — the socket travels as an ordinary prop.
+ */
+export function AddPlugShowcase({ socket }: { socket: string }) {
+  const { close } = useMPTModal();
+  const context = useMPTContext();
+  const [format, setFormat] = useState<Format>('yaml');
+  const [plug, setPlug] = useState<PlugConfig>({
+    id: '',
+    name: '',
+    description: '',
+    href: '/static/',
+    condition: '',
+  });
+
+  const update =
+    (field: keyof PlugConfig) => (e: React.ChangeEvent<unknown>) =>
+      setPlug((p) => ({ ...p, [field]: (e.target as HTMLInputElement).value }));
+
+  const output = format === 'yaml' ? toYaml(plug, socket) : toJson(plug, socket);
+
+  const body = (
+    <>
+      <p>
+        Fill in the fields below to generate plug configuration. In this playground plugs are declared
+        in Python via a <code>PlugRouter</code> — but the same fields (<code>id</code>,{' '}
+        <code>name</code>, <code>description</code>, <code>socket</code>, <code>href</code>,{' '}
+        <code>condition</code>) map one-to-one, so you can use this as a scratchpad. Then build a JS
+        bundle at the <code>href</code> path you specified.
+      </p>
+
+      <div className="add-plug__form">
+        <Input
+          name="id"
+          label="Plug ID"
+          placeholder="my-plug"
+          value={plug.id}
+          onChange={update('id')}
+          description="Unique identifier (required)"
+        />
+        <Input
+          name="name"
+          label="Name"
+          placeholder="My Plug"
+          value={plug.name}
+          onChange={update('name')}
+        />
+        <Input
+          name="description"
+          label="Description"
+          placeholder="Short description"
+          value={plug.description}
+          onChange={update('description')}
+        />
+        <Input
+          name="href"
+          label="Bundle href"
+          placeholder="/static/my-plug/index.js"
+          value={plug.href}
+          onChange={update('href')}
+          description="Relative path to the JS bundle"
+        />
+        <Input
+          name="condition"
+          label="Condition (RQL)"
+          placeholder="eq(product.id,PRD-1234-5678)"
+          value={plug.condition}
+          onChange={update('condition')}
+          description="Optional RQL expression to control visibility"
+        />
+
+        <details className="add-plug__context">
+          <summary>Current context</summary>
+          <pre>
+            <code>{JSON.stringify(context, null, 2)}</code>
+          </pre>
+        </details>
+      </div>
+
+      <Divider />
+
+      <Switcher
+        name="format"
+        label="Output format"
+        options={formatOptions}
+        value={format}
+        onChange={(e) => setFormat(e.target.value as Format)}
+      />
+      <div className="add-plug__output">
+        <pre>
+          <code>{output}</code>
+        </pre>
+      </div>
+    </>
+  );
+
+  if (socket.endsWith('.actions')) {
+    return (
+      <div className="dialog">
+        <div className="dialog__header">
+          <div className="dialog__title">Add a Plug to {socket}</div>
+        </div>
+        <div className="dialog__content">{body}</div>
+        <div className="dialog__actions">
+          <div />
+          <Button type="secondary" onClick={() => close()}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (socket === 'portal') {
+    return <Card>{body}</Card>;
+  }
+
+  return <div className="add-plug">{body}</div>;
+}

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -4,6 +4,35 @@
 @use 'fixes/modal-layout';
 @use 'fixes/wizard';
 
+// Raw-HTML typography used by the showcase modules (examples, guide, dialog,
+// add). Existing product modules render text through BoldText/RegularText, so
+// these element-level rules only affect the ported showcase content.
+h1, .__h1 {
+  @extend %regular6;
+}
+
+h2, .__h2 {
+  @extend %regular5;
+}
+
+h3, .__h3 {
+  @extend %regular4;
+}
+
+code, .__code {
+  background-color: var(--gray-1);
+  padding: 2px 6px;
+  border-radius: var(--radius-s);
+  font-family: monospace;
+}
+
+pre, .__pre {
+  background-color: var(--gray-1);
+  padding: var(--spacing-3);
+  border-radius: var(--radius-m);
+  overflow-x: auto;
+}
+
 // Base typography on every element. The `%regular2` placeholder comes from the
 // SDK design tokens and provides the line-height / font-size / font-family the
 // platform host applies globally. We apply it here (top-level) because dart-sass


### PR DESCRIPTION
> ⚠️ **This pull request was created by an AI agent (Claude Code).** Review carefully before merging.

## What

Ports the frontend UI SDK showcase from `mpt-extension-example` into the playground:

- **`examples`** — a react-router tabbed app: Introduction, Basics, Context (`useMPTContext`), API calls (SDK `http` feeding a server-driven `Grid` via `useGridWithRql` + RQL), and UI elements (buttons, inputs, selects, toggles, date pickers, grids, entity references).
- **`guide`** — bundled Markdown rendered with `InlineMarkdown`.
- **`add-*`** — a per-socket "plug here" showcase covering the remaining Portal sockets; all mount a shared `AddPlugShowcase` component (native per-socket model: one module = one plug, no build-time fan-out, no socket manifest).

Backend: the showcase plugs are registered **per entity** — one `PlugRouter` file each under `routers/plugs/` (`portal`, `orders`, `subscriptions`, `assets`, `accounts`, plus the agreements `add` plug in the existing `agreements` router), sharing an `add_plug` helper in `common.py`; all wired into `app.py`. Mirrors the per-entity organisation of the existing agreement plugs. Adds `react-router` and `@softwareone-platform/rql-client`; adds jest tests; updates docs (README, `docs/architecture.md`, `docs/examples.md`).

## Deferred (out of scope)

- Socket-less modal round-trip demo (dialog/wizard via `open()`) — MPT-22801 / MPT-22804.
- Nested navigation via a container plug — MPT-22802 / MPT-22806.

## Testing

- frontend: `npm run check` (tsc + eslint, max-warnings=0) ✓, `npm test` 26/26 ✓
- backend: `pytest` 15/15 ✓; ruff / ruff format / mypy ✓ (pre-commit passed)

## Jira

MPT-22857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22857](https://softwareone.atlassian.net/browse/MPT-22857)

- Added a Marketplace Portal UI SDK showcase to the playground, including an `examples` tabbed React app, a `guide` module rendering Markdown via `InlineMarkdown`, and per-socket `add-*` demo entrypoints.
- Introduced a shared `AddPlugShowcase` component that generates YAML/JSON plug configs and previews current context, with Jest tests and supporting styles.
- Built new frontend examples for Intro, Basics, Context, and API/RQL usage, plus UI element demos (buttons, inputs, selects, toggles, date pickers, grids, entity references).
- Implemented backend showcase plug routers per entity (`portal`, `orders`, `subscriptions`, `assets`, `accounts`, plus agreements `add`) and wired them into the app.
- Added frontend dependencies (`react-router`, `@softwareone-platform/rql-client`) and updated documentation (`README`, `docs/architecture.md`, `docs/examples.md`) to reflect the new routing/showcase structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22857]: https://softwareone.atlassian.net/browse/MPT-22857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ