### PR TITLE
MPT-22978 Scope release version check to the same major

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -71,16 +71,20 @@ jobs:
             exit 1
           fi
 
-          # 4. The version must be strictly greater than the highest tag reachable
-          #    from the dispatched ref (monotonic increase per branch). The version
+          # 4. The version must be strictly greater than the highest tag of the same
+          #    major reachable from the dispatched ref (monotonic increase per release
+          #    line). Only same-major tags are considered so a maintenance line
+          #    (e.g. release/5 -> 5.x) is not blocked by a higher major present in
+          #    shared history (e.g. a 6.0.0 tag inherited from main). The version
           #    itself is excluded so a leftover tag from an interrupted run does not
           #    block its own completion.
+          MAJOR="${VERSION%%.*}"
           LATEST="$(git tag --merged HEAD --sort=-v:refname \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -vx "${VERSION}" | head -n1 || true)"
+            | grep -E "^${MAJOR}\.[0-9]+\.[0-9]+$" | grep -vx "${VERSION}" | head -n1 || true)"
           if [ -n "${LATEST}" ]; then
             HIGHEST="$(printf '%s\n%s\n' "${LATEST}" "${VERSION}" | sort -V | tail -n1)"
             if [ "${HIGHEST}" != "${VERSION}" ]; then
-              echo "::error::Version '${VERSION}' must be greater than the latest reachable tag '${LATEST}'."
+              echo "::error::Version '${VERSION}' must be greater than the latest reachable ${MAJOR}.x tag '${LATEST}'."
               exit 1
             fi
           fi

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -77,16 +77,20 @@ jobs:
             exit 1
           fi
 
-          # 4. The version must be strictly greater than the highest tag reachable
-          #    from the dispatched ref (monotonic increase per branch). The version
+          # 4. The version must be strictly greater than the highest tag of the same
+          #    major reachable from the dispatched ref (monotonic increase per release
+          #    line). Only same-major tags are considered so a maintenance line
+          #    (e.g. release/5 -> 5.x) is not blocked by a higher major present in
+          #    shared history (e.g. a 6.0.0 tag inherited from main). The version
           #    itself is excluded so a leftover tag from an interrupted run does not
           #    block its own completion.
+          MAJOR="${VERSION%%.*}"
           LATEST="$(git tag --merged HEAD --sort=-v:refname \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -vx "${VERSION}" | head -n1 || true)"
+            | grep -E "^${MAJOR}\.[0-9]+\.[0-9]+$" | grep -vx "${VERSION}" | head -n1 || true)"
           if [ -n "${LATEST}" ]; then
             HIGHEST="$(printf '%s\n%s\n' "${LATEST}" "${VERSION}" | sort -V | tail -n1)"
             if [ "${HIGHEST}" != "${VERSION}" ]; then
-              echo "::error::Version '${VERSION}' must be greater than the latest reachable tag '${LATEST}'."
+              echo "::error::Version '${VERSION}' must be greater than the latest reachable ${MAJOR}.x tag '${LATEST}'."
               exit 1
             fi
           fi


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Scope the release version-monotonicity check to the dispatched version's own major, in both release templates (`release-extension.yml`, `release-library.yml`).

## Why
`workflow_dispatch` executes the workflow file from the **selected ref**. On a `release/N` branch the check evaluated `git tag --merged HEAD` across **all** majors, so a higher-major tag (`6.0.0`) inherited from `main` through shared history blocked cutting a lower major — dispatching `5.0.0` on `release/5` failed with *"must be greater than the latest reachable tag '6.0.0'"*. These templates are the source copied into the extension repos, so the defect propagated from here.

## Change
Derive `MAJOR` from the input version and compare only against `${MAJOR}.x` tags. Each release line stays monotonic within its own major; going backwards inside the same major is still blocked.

Jira: MPT-22978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Tightened release version monotonicity checks in both release workflows to compare against reachable tags within the same major version only.
- Derived `MAJOR` from the dispatched version and filtered candidate tags to `${MAJOR}.x` / `^${MAJOR}\.[0-9]+\.[0-9]+$`.
- Excluded the current input version from tag comparison and updated the validation error message to reference the latest reachable tag on the same major line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->