### PR TITLE
MPT-23016 Link the shared UI testing standard

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,6 +10,7 @@ Shared rules live in `mpt-extension-skills/standards` and should not be duplicat
 - dependency management: [packages-and-dependencies.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/packages-and-dependencies.md)
 - extension design guidance: [extensions-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-best-practices.md)
 - frontend UI authoring rules: [extensions-ui-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-ui-best-practices.md)
+- frontend UI testing rules: [extensions-ui-testing-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-ui-testing-best-practices.md)
 - pull request rules: [pull-requests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/pull-requests.md)
 - Python coding conventions: [python-coding.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/python-coding.md)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Shared unit-test rules live in [unittests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/unittests.md).
+Shared unit-test rules live in [unittests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/unittests.md). Frontend (UI) tests follow [extensions-ui-testing-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-ui-testing-best-practices.md).
 
 Shared build and target knowledge also applies:
 


### PR DESCRIPTION
> ⚠️ **This pull request was created by an AI agent (Claude Code).** Review carefully before merging.

## What

Adds the frontend UI **testing** standard ([extensions-ui-testing-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-ui-testing-best-practices.md)) to `docs/contributing.md` (next to the UI authoring standard) and `docs/testing.md`.

Part of MPT-23014 (split the UI standard into UI + UI-testing). The UI-testing standard lands via mpt-extension-skills PR #82.

## Jira

MPT-23016

## Testing

Docs-only; links resolve once mpt-extension-skills #82 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23016](https://softwareone.atlassian.net/browse/MPT-23016)

- Added a shared UI testing standard link (`extensions-ui-testing-best-practices.md`) to `docs/contributing.md`.
- Updated `docs/testing.md` to include a separate reference for frontend/UI tests while keeping the existing shared unit-test rules link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23016]: https://softwareone.atlassian.net/browse/MPT-23016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ