### PR TITLE
MPT-22806 Demo nested navigation via a container plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ static/*
 # Frontend
 **/node_modules/
 **/dist/
+
+# Claude
+.claude

--- a/backend/swo_playground/routers/plugs/portal.py
+++ b/backend/swo_playground/routers/plugs/portal.py
@@ -1,5 +1,5 @@
 from mpt_extension_sdk.routing import PlugRouter
-from mpt_extension_sdk.routing.plugs import Plug
+from mpt_extension_sdk.routing.plugs import NavigationPlug, Plug
 
 from swo_playground.routers.plugs.common import add_plug
 
@@ -7,21 +7,28 @@ portal_router = PlugRouter()
 
 
 @portal_router.register()
-def portal_plugs() -> list[Plug]:
-    """Declare top-level portal plugs: the examples app, the guide and the add showcase."""
+def portal_plugs() -> list[Plug | NavigationPlug]:
+    """Declare top-level portal plugs: the learn group with its children and the add showcase."""
+    learn_extensions = NavigationPlug(
+        id="learn-extensions",
+        name="Learn extensions",
+        description="Guides and examples for extensions development.",
+        socket="portal",
+    )
     return [
+        learn_extensions,
         Plug(
             id="examples",
             name="Extension examples",
             description="Learn more about the extensions UI SDK and its capabilities.",
-            socket="portal",
+            socket=learn_extensions.nested_socket,
             href="/static/examples/index.js",
         ),
         Plug(
             id="guide",
             name="Extension guide",
             description="Read about the essential basics of extensions development.",
-            socket="portal",
+            socket=learn_extensions.nested_socket,
             href="/static/guide/index.js",
         ),
         add_plug("portal"),

--- a/backend/tests/routers/test_showcase_plugs.py
+++ b/backend/tests/routers/test_showcase_plugs.py
@@ -27,12 +27,19 @@ def _socket_href(plug) -> tuple[str, str]:
     return plug.socket, plug.href
 
 
+def test_learn_extensions_container_registered():
+    result = {plug.id: plug.model_dump() for plug in ext_app.to_meta_config().plugs}
+
+    assert result["learn-extensions"]["socket"] == "portal"
+    assert result["learn-extensions"]["href"] is None
+
+
 def test_portal_showcase_plugs_registered():
     result = {plug.id: plug.model_dump() for plug in ext_app.to_meta_config().plugs}
 
-    assert result["examples"]["socket"] == "portal"
+    assert result["examples"]["socket"] == "portal.learn-extensions"
     assert result["examples"]["href"] == "/static/examples/index.js"
-    assert result["guide"]["socket"] == "portal"
+    assert result["guide"]["socket"] == "portal.learn-extensions"
     assert result["guide"]["href"] == "/static/guide/index.js"
 
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -25,7 +25,7 @@ sync) — so you can exercise the playground without writing requests by hand.
 - `events_orders_router` — order event handling
 - `events_agreements_router` — agreement event handling
 - `api_agreements_router` — agreement API endpoints
-- `plug_portal_router` — top-level portal plugs (examples app, guide, `add` showcase)
+- `plug_portal_router` — top-level portal plugs (the `learn-extensions` navigation group with the examples app and guide nested under it, plus the `add` showcase)
 - `plug_agreements_router` — agreement plugs (the real examples plus the agreements `add` showcase)
 - `plug_orders_router` / `plug_subscriptions_router` / `plug_assets_router` / `plug_accounts_router` — per-entity `add` showcase plugs
 
@@ -116,7 +116,8 @@ Each module's `index.tsx` follows the same entry-point pattern: import the
 These plugs demonstrate the UI SDK breadth rather than a specific business flow.
 Like the agreement plugs, they are organised **per entity** — one `PlugRouter`
 file each: [`portal.py`](../backend/swo_playground/routers/plugs/portal.py)
-(top-level: examples, guide, `add`), [`orders.py`](../backend/swo_playground/routers/plugs/orders.py),
+(top-level: the `learn-extensions` group with examples and guide, `add`),
+[`orders.py`](../backend/swo_playground/routers/plugs/orders.py),
 [`subscriptions.py`](../backend/swo_playground/routers/plugs/subscriptions.py),
 [`assets.py`](../backend/swo_playground/routers/plugs/assets.py),
 [`accounts.py`](../backend/swo_playground/routers/plugs/accounts.py), and the
@@ -124,8 +125,9 @@ agreements `add` plug in [`agreements.py`](../backend/swo_playground/routers/plu
 
 | Plug id / socket | Frontend module | Demonstrates |
 | --- | --- | --- |
-| `examples` — `portal` | [`modules/examples/`](../frontend/src/modules/examples/) | A multi-tab React app (`react-router`) touring the UI SDK: Introduction, Basics, Context (`useMPTContext`), API calls (the `http` client feeding a server-driven `Grid` via `useGridWithRql` + RQL), and UI elements (buttons, inputs, selects, toggles, date pickers, grids, entity references) |
-| `guide` — `portal` | [`modules/guide/`](../frontend/src/modules/guide/) | Rendering bundled Markdown with `InlineMarkdown` (esbuild `.md` text loader) |
+| `learn-extensions` — `portal` | — (no bundle) | A `NavigationPlug` container: a href-less navigation grouping node whose id derives the nested socket `portal.learn-extensions` for the two plugs below |
+| `examples` — `portal.learn-extensions` | [`modules/examples/`](../frontend/src/modules/examples/) | A multi-tab React app (`react-router`) touring the UI SDK: Introduction, Basics, Context (`useMPTContext`), API calls (the `http` client feeding a server-driven `Grid` via `useGridWithRql` + RQL), and UI elements (buttons, inputs, selects, toggles, date pickers, grids, entity references) |
+| `guide` — `portal.learn-extensions` | [`modules/guide/`](../frontend/src/modules/guide/) | Rendering bundled Markdown with `InlineMarkdown` (esbuild `.md` text loader) |
 | `add-<socket>` (one per socket) | [`modules/add-*/`](../frontend/src/modules/) | A "plug here" scaffold shown on every remaining Portal socket, so the full set of sockets is covered |
 
 The `add-*` plugs cover many near-identical sockets without duplicating logic:

--- a/frontend/src/modules/guide/text.md
+++ b/frontend/src/modules/guide/text.md
@@ -46,6 +46,32 @@ def showcase_plugs() -> list[Plug]:
 
 The router is then mounted on the extension app with `ext_app.include_router(showcase_router)`.
 
+### Nested Navigation
+
+To group Plugs under a two-level navigation entry, declare a `NavigationPlug` — a pure navigation
+container that ships no bundle (no `href`). Its `id` derives a nested socket (`<socket>.<id>`),
+exposed as `nested_socket`, that child Plugs target:
+
+```python
+from mpt_extension_sdk.routing.plugs import NavigationPlug, Plug
+
+learn_extensions = NavigationPlug(
+    id="learn-extensions",
+    name="Learn extensions",
+    socket="portal",
+)
+guide = Plug(
+    id="guide",
+    name="Extension guide",
+    description="Read about the essential basics of extensions development.",
+    socket=learn_extensions.nested_socket,  # portal.learn-extensions
+    href="/static/guide/index.js",
+)
+```
+
+This very guide is registered that way: the playground nests `guide` and `examples` under the
+`learn-extensions` group in the portal navigation.
+
 ## Building the Frontend
 
 Each directory under `frontend/src/modules` is an entry point. `esbuild` bundles every


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Demonstrates the SDK's nested-navigation support ([MPT-22805](https://softwareone.atlassian.net/browse/MPT-22805), shipped in mpt-extension-sdk 6.5) in the playground:

- Registered a href-less `NavigationPlug` container `learn-extensions` on the `portal` socket in `backend/swo_playground/routers/plugs/portal.py`.
- Moved the `guide` and `examples` plugs from top-level `portal` onto the container's derived nested socket `portal.learn-extensions`, reproducing the two-level navigation from `mpt-extension-example`.
- Updated `docs/examples.md` and the bundled extension guide (`frontend/src/modules/guide/text.md`) to describe the container-plug pattern.
- Extended `backend/tests/routers/test_showcase_plugs.py` to cover the container registration and the nested sockets.
- Also carries a small `.gitignore` addition for the `.claude` directory.

## Notes for reviewers

- Rebased onto main after #102; the SDK 6.5 dependency bump this PR originally carried is superseded by that PR and no longer part of the diff.
- Generated metadata emits the container without an `href`; `mpt-ext meta validate` passes.
- The per-socket `add` showcase plugs intentionally stay on their existing sockets; no `add` plug was added for the new nested socket to keep this change scoped to the ticket.
- Verified with `make build` + `make check-all` (backend + frontend checks and tests, frontend build, metadata validation) against SDK 6.5.2.

Jira: [MPT-22806](https://softwareone.atlassian.net/browse/MPT-22806)

[MPT-22805]: https://softwareone.atlassian.net/browse/MPT-22805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-22806]: https://softwareone.atlassian.net/browse/MPT-22806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds nested navigation support in the playground using a `learn-extensions` container under the `portal` socket.
- Moves the `guide` and `examples` plugs to `portal.learn-extensions`.
- Documents the container-plug and nested navigation patterns.
- Adds tests for container registration and nested sockets.
- Adds `.claude` to `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->