### PR TITLE
MPT-23439 Ship scss/md ambient shim with emitted type declarations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:code": "node esbuild.config.js",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "tsc -p tsconfig.build.json && cp src/globals.d.ts ../static/types/",
     "build": "npm run build:code && npm run build:types",
     "check": "tsc -p tsconfig.json --noEmit && eslint src --max-warnings=0",
     "format": "eslint src --fix",


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

The frontend type build (`npm run build:types`, `tsc -p tsconfig.build.json` with `emitDeclarationOnly`) emits `.d.ts` files into `static/types/`. TypeScript preserves side-effect imports such as `import './AddPlugShowcase.scss'` in the emitted declarations, but the ambient module shim `frontend/src/globals.d.ts` (`declare module '*.scss'` and the `'*.md'` declaration) was not part of the output. The generated tree therefore did not type-check standalone, and IDEs opening a generated `.d.ts` reported "Cannot find module './AddPlugShowcase.scss'".

This change makes `build:types` copy the shim into `static/types/` after the `tsc` emit, so the emitted declarations resolve on their own.

## Testing

- `make build scope=frontend` — succeeds; `static/types/globals.d.ts` is now present in the output.
- Standalone type-check of the emitted `static/types/` tree inside the frontend container with `skipLibCheck: false` — no scss/md resolution errors. Negative control: removing the shim reproduces `error TS2882: Cannot find module or type declarations for side-effect import of '../../style.scss'`.
- `make check-all scope=frontend` — checks pass, 8 test suites / 33 tests pass.

Jira: https://softwareone.atlassian.net/browse/MPT-23439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23439](https://softwareone.atlassian.net/browse/MPT-23439)

- Updated `build:types` to copy `globals.d.ts` alongside emitted declarations.
- Enables standalone type-checking and IDE resolution of `.scss` and `.md` module imports.
- Validated with successful builds and passing frontend checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23439]: https://softwareone.atlassian.net/browse/MPT-23439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ